### PR TITLE
chore: release v1.3.0

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,13 @@
+Create a GitHub issue. Describe the bug or feature request as the argument. Usage: /issue <description>
+
+Determine whether the description sounds like a bug or a feature request, then create the issue with `gh issue create` using the following structure:
+
+**For a bug:**
+- Title: "fix: <short description>"
+- Body sections: **Describe the bug**, **Steps to reproduce**, **Expected behaviour**, **Actual behaviour**, **Possible cause** (reference relevant lines in `src/index.ts` if applicable), **Environment** (Bun version, TypeScript version).
+
+**For a feature request:**
+- Title: "feat: <short description>"
+- Body sections: **Problem**, **Proposed solution**, **Alternatives considered**, **Affected API** (list any methods in `src/types/ttid.d.ts` that would change).
+
+Apply the appropriate label (`bug` or `enhancement`) via `--label`. Print the issue URL when done.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,13 @@
+Create a pull request for the current branch into `main`.
+
+1. Run `git status` and stop if there are uncommitted changes — ask the user to commit or stash them first.
+2. Run `git log main..HEAD --oneline` to list commits on this branch.
+3. Run `git diff main...HEAD` to understand all changes.
+4. Push the branch to origin if it has no upstream: `git push -u origin HEAD`.
+5. Create the PR with `gh pr create` using:
+   - A concise title (≤ 70 chars) derived from the branch name and commits.
+   - A body with three sections:
+     - **Summary** — bullet list of what changed and why.
+     - **Test plan** — checklist of how to verify the changes (reference `bun test` where relevant).
+     - **Breaking changes** — any changes to public API in `src/types/ttid.d.ts`; write "None" if there are none.
+6. Print the PR URL.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,44 @@
+Create a release branch, publish to npm via CI, then merge to main.
+
+1. Run `bun test` and stop if any tests fail.
+
+2. Determine the new version automatically based on unreleased commits:
+   `git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --oneline`
+
+   Apply these rules to select the bump type:
+   - **major** — any commit with a `!` breaking-change marker (e.g. `feat!:`, `fix!:`) or a `BREAKING CHANGE` footer.
+   - **minor** — one or more `feat:` commits and no breaking changes.
+   - **patch** — only `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, or `perf:` commits.
+
+   Compute the new version by incrementing the corresponding part of the current `"version"` in `package.json` and resetting lower parts to zero. Show the chosen version and the reasoning to the user before proceeding.
+
+3. Update `"version"` in `package.json` to the new version.
+
+4. Fetch the latest main and create a release branch from it:
+   ```
+   git fetch origin main
+   git checkout -b release/<version> origin/main
+   ```
+
+5. Stage all changes and commit:
+   `git add -A && git commit -m "chore: release v<version>"`
+
+6. Push the branch:
+   `git push -u origin release/<version>`
+
+7. Tell the user that the `publish` workflow will now run on GitHub Actions:
+   - It verifies the branch name matches `package.json` version.
+   - It runs tests, publishes to npm, creates a git tag, and opens a GitHub release.
+   - The NPM_TOKEN secret must be set in repo Settings → Secrets → Actions.
+
+8. Once the workflow passes (user confirms), create a PR and merge it to main:
+   ```
+   gh pr create --title "chore: release v<version>" --body "Release v<version>" --base main --head release/<version>
+   gh pr merge --merge --delete-branch
+   ```
+
+9. Switch back to main and pull:
+   ```
+   git checkout main
+   git pull
+   ```

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,13 @@
+Review the pull request given as an argument (PR number or URL). Usage: /review-pr 42
+
+1. Fetch the PR details: `gh pr view <arg> --json title,body,headRefName,baseRefName,files`
+2. Fetch the diff: `gh pr diff <arg>`
+3. Review the changes with focus on:
+   - **Correctness** — logic errors, edge cases missed in `generate`, `isTTID`, or `decodeTime`.
+   - **Type safety** — use of `any` instead of `unknown`, missing type guards.
+   - **Tests** — whether new behaviour is covered in `test/ttid.test.ts`; flag any missing cases.
+   - **Public API** — unintended changes to `src/types/ttid.d.ts`.
+   - **CI** — whether the workflow files in `.github/workflows/` are still valid for the change.
+4. Post the review as inline comments using `gh pr review <arg> --comment --body "<feedback>"`.
+   Group feedback by file. Prefix each point with **[suggestion]**, **[issue]**, or **[nit]**.
+5. Summarise the overall verdict: Approve / Request changes / Comment only.

--- a/.claude/commands/sync-main.md
+++ b/.claude/commands/sync-main.md
@@ -1,0 +1,9 @@
+Safely bring the current branch up to date with the latest `main` from origin.
+
+1. Confirm the current branch with `git branch --show-current`. If already on `main`, just run `git pull` and stop.
+2. Stash any uncommitted changes with `git stash push -m "sync-main auto-stash"` and note whether anything was stashed.
+3. Fetch the latest: `git fetch origin main`.
+4. Rebase the current branch onto `origin/main`: `git rebase origin/main`.
+5. If the rebase has conflicts, list the conflicting files and stop — ask the user to resolve them, then run `git rebase --continue`.
+6. If a stash was created in step 2, restore it with `git stash pop`.
+7. Report: commits rebased, files changed, any stash restored.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [release/*]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Bun ${{ matrix.bun-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        bun-version: [latest, 1.2.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: Publish
+
+on:
+  push:
+    branches: [release/*]
+
+jobs:
+  test:
+    name: Test before publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write   # create git tags
+      id-token: write   # npm provenance
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Setup Node and upgrade npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Resolve version from branch
+        id: version
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          VERSION="${BRANCH#release/}"
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "Branch version ($VERSION) does not match package.json ($PKG_VERSION). Skipping publish."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm (Trusted Publishing via OIDC)
+        run: |
+          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+          npm publish --access public --provenance
+
+      - name: Create and push version tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f -a "v${{ steps.version.outputs.version }}" -m "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}" --force
+
+      - name: Create GitHub release
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "semi": false,
+    "singleQuote": true,
+    "tabWidth": 4,
+    "trailingComma": "none",
+    "printWidth": 100
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,17 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@vyckr/ttid",
       "devDependencies": {
         "@types/bun": "^1.2.10",
         "@types/node": "^20.4.2",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "prettier": "^3.0.0",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -13,14 +19,230 @@
     },
   },
   "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
     "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@20.17.46", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw=="],
 
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/type-utils": "8.58.0", "@typescript-eslint/utils": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.0", "@typescript-eslint/types": "^8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0" } }, "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.0", "@typescript-eslint/tsconfig-utils": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
     "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,6 @@ export default [
     },
     prettierConfig,
     {
-        ignores: ['bin/**', 'node_modules/**']
+        ignores: ['bin/**', 'node_modules/**', '**/*.d.ts']
     }
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import tsPlugin from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
+import prettierConfig from 'eslint-config-prettier'
+
+export default [
+    {
+        files: ['src/**/*.ts', 'test/**/*.ts'],
+        languageOptions: {
+            parser: tsParser,
+            parserOptions: {
+                project: './tsconfig.json'
+            }
+        },
+        plugins: {
+            '@typescript-eslint': tsPlugin
+        },
+        rules: {
+            ...tsPlugin.configs['recommended'].rules,
+            '@typescript-eslint/no-explicit-any': 'error',
+            '@typescript-eslint/explicit-function-return-type': 'warn',
+            '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
+        }
+    },
+    prettierConfig,
+    {
+        ignores: ['bin/**', 'node_modules/**']
+    }
+]

--- a/package.json
+++ b/package.json
@@ -1,11 +1,22 @@
 {
   "name": "@vyckr/ttid",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "main": "./src/index.ts",
   "types": "./src/types/index.d.ts",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src test",
+    "format": "prettier --write src test"
+  },
   "devDependencies": {
     "@types/bun": "^1.2.10",
-    "@types/node": "^20.4.2"
+    "@types/node": "^20.4.2",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "^3.0.0"
   },
   "type": "module",
   "peerDependencies": {
@@ -20,7 +31,7 @@
     "typescript",
     "bun",
     "generate",
-    "identifer"
+    "identifier"
   ],
   "author": "Chidelma",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,90 +1,139 @@
-export default class {
+export default class TTID {
 
-    private static multiple = 10000
+    /**
+     * Multiplier applied to high-resolution timestamps to preserve sub-millisecond
+     * precision when encoding to base-36. A value of 10,000 gives ~0.1ms resolution.
+     */
+    private static readonly PRECISION = 10_000
 
-    private static base = 36
+    /**
+     * Encoding base for timestamp segments. Base-36 uses digits 0–9 and letters A–Z,
+     * yielding compact 11-character timestamps for current Unix millisecond values.
+     */
+    private static readonly BASE = 36
 
-    private static placeholder = 'X'
+    /**
+     * Segment placeholder used when an ID is deleted without a prior update,
+     * preserving the three-segment TTID structure.
+     */
+    private static readonly PLACEHOLDER = 'X'
 
-    private static timeNow = () => (performance.now() + performance.timeOrigin) * this.multiple
+    /** Minimum accepted timestamp (ms since epoch): 2020-01-01T00:00:00.000Z */
+    private static readonly MIN_TIMESTAMP_MS = 1_577_836_800_000
 
-    private static isTTIDFormat = (_id: string) => _id.match(/^[A-Z0-9]{11}(-[A-Z0-9]{1,11}){0,2}$/i)
-    
-    static isTTID(_id: string) {
+    /** Maximum accepted timestamp (ms since epoch): 2200-01-01T00:00:00.000Z */
+    private static readonly MAX_TIMESTAMP_MS = 7_258_118_400_000
 
-        let isValid: RegExpMatchArray | Date | null = this.isTTIDFormat(_id)
+    /** Cached compiled regex for TTID format validation, avoiding repeated recompilation. */
+    private static readonly TTID_PATTERN = /^[A-Z0-9]{11}(-[A-Z0-9]{1,11}){0,2}$/i
 
-        if(!isValid) return isValid
+    /** Cached compiled regex for UUID format validation. */
+    private static readonly UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+    private static timeNow(): number {
+        return (performance.now() + performance.timeOrigin) * this.PRECISION
+    }
+
+    /**
+     * Checks whether a string is a valid TTID.
+     * @param _id - The string to validate.
+     * @returns The creation `Date` if valid, or `null` if not.
+     */
+    static isTTID(_id: string): Date | null {
+
+        if (!this.TTID_PATTERN.test(_id)) return null
 
         try {
-
             const { createdAt, updatedAt, deletedAt } = this.decodeTime(_id)
-            
-            if(updatedAt) new Date(updatedAt)
 
-            if(deletedAt) new Date(deletedAt)
-            
-            isValid = new Date(createdAt)
+            if (updatedAt !== undefined) new Date(updatedAt)
+            if (deletedAt !== undefined) new Date(deletedAt)
 
+            return new Date(createdAt)
         } catch {
-
-            isValid = null
+            return null
         }
-
-        return isValid
     }
 
-    static isUUID(_id: string) {
-
-        return _id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    /**
+     * Checks whether a string is a valid UUID (any version or variant).
+     * @param _id - The string to validate.
+     * @returns A `RegExpMatchArray` if valid, or `null` if not.
+     */
+    static isUUID(_id: string): RegExpMatchArray | null {
+        return _id.match(this.UUID_PATTERN)
     }
 
-    static generate(_id?: string, del: boolean = false) {
+    /**
+     * Generates a new TTID or advances an existing one through its lifecycle.
+     *
+     * - No arguments: creates a new single-segment TTID.
+     * - `_id` only: updates the TTID, producing a two-segment ID.
+     * - `_id` + `del: true`: marks the TTID as deleted, producing a three-segment ID.
+     *
+     * @param _id - An existing TTID to update or delete. Omit to create a new one.
+     * @param del - When `true`, marks the TTID as deleted.
+     * @returns The new or advanced TTID.
+     * @throws {Error} If `_id` is already deleted (three-segment) or is not a valid TTID.
+     */
+    static generate(_id?: string, del: boolean = false): _ttid {
 
-        if(_id && this.isTTID(_id) && _id.split('-').length === 3) throw new Error('This identifer can no longer be modified') 
+        if (_id && this.isTTID(_id) && _id.split('-').length === 3) {
+            throw new Error('This identifier can no longer be modified')
+        }
 
         const time = this.timeNow()
-        
-        if(_id && this.isTTID(_id) && del) {
+
+        if (_id && this.isTTID(_id) && del) {
 
             const [created, updated] = _id.split('-')
+            const deleted = time.toString(this.BASE)
 
-            const deleted = time.toString(this.base)
-
-            return `${created}-${updated ?? this.placeholder}-${deleted}`.toUpperCase() as _ttid
+            return `${created}-${updated ?? this.PLACEHOLDER}-${deleted}`.toUpperCase() as _ttid
         }
 
-        if(_id && this.isTTID(_id)) {
+        if (_id && this.isTTID(_id)) {
 
             const [created] = _id.split('-')
-
-            const updated = time.toString(this.base)
+            const updated = time.toString(this.BASE)
 
             return `${created}-${updated}`.toUpperCase() as _ttid
         }
 
-        if(_id && !this.isTTID(_id)) throw new Error("Invalid TTID!")
+        if (_id && !this.isTTID(_id)) throw new Error('Invalid TTID!')
 
-        const timeCode = time.toString(this.base)
-
-        return timeCode.toUpperCase() as _ttid
+        return time.toString(this.BASE).toUpperCase() as _ttid
     }
 
-    static decodeTime(_id: string) {
+    /**
+     * Decodes the timestamps embedded in a TTID.
+     * @param _id - A valid TTID string.
+     * @returns An object with `createdAt`, and optionally `updatedAt` and `deletedAt` (ms since epoch).
+     * @throws {Error} If the format is invalid or any segment encodes an out-of-range timestamp.
+     */
+    static decodeTime(_id: string): _timestamps {
 
-        if(!this.isTTIDFormat(_id)) throw new Error(`Invalid Format!`)
+        if (!this.TTID_PATTERN.test(_id)) throw new Error('Invalid Format!')
 
         const [created, updated, deleted] = _id.split('-')
 
-        const convertToMilliseconds = (timeCode: string) => Number((parseInt(timeCode, this.base) / this.multiple).toFixed(0))
+        const convertToMilliseconds = (timeCode: string): number => {
+            const ms = Number((parseInt(timeCode, this.BASE) / this.PRECISION).toFixed(0))
+
+            if (!isFinite(ms) || ms < this.MIN_TIMESTAMP_MS || ms > this.MAX_TIMESTAMP_MS) {
+                throw new Error(`Timestamp out of valid range in segment: ${timeCode}`)
+            }
+
+            return ms
+        }
 
         const timestamps: _timestamps = {
             createdAt: convertToMilliseconds(created)
         }
 
-        if(updated && updated !== this.placeholder) timestamps.updatedAt = convertToMilliseconds(updated)
-        if(deleted) timestamps.deletedAt = convertToMilliseconds(deleted)
+        if (updated && updated !== this.PLACEHOLDER) timestamps.updatedAt = convertToMilliseconds(updated)
+        if (deleted) timestamps.deletedAt = convertToMilliseconds(deleted)
 
         return timestamps
     }
-}                                      
+}

--- a/src/types/ttid.d.ts
+++ b/src/types/ttid.d.ts
@@ -1,12 +1,14 @@
-export type _ttid = string | `${string}-${string}` | `${string}-${string}-${string}`
-
-export interface _timestamps {
-    createdAt: number
-    updatedAt?: number
-    deletedAt?: number
-}
-
 declare module "@vyckr/ttid" {
+
+    /** Branded string type representing a TTID in one of its three lifecycle states. */
+    export type _ttid = string | `${string}-${string}` | `${string}-${string}-${string}`
+
+    /** Decoded timestamps extracted from a TTID. */
+    export interface _timestamps {
+        createdAt: number
+        updatedAt?: number
+        deletedAt?: number
+    }
 
     export default class TTID {
 
@@ -42,3 +44,7 @@ declare module "@vyckr/ttid" {
         static decodeTime(_id: string): _timestamps
     }
 }
+
+// Global ambient aliases so src/index.ts can reference these types without an import.
+type _ttid = import("@vyckr/ttid")._ttid
+type _timestamps = import("@vyckr/ttid")._timestamps

--- a/src/types/ttid.d.ts
+++ b/src/types/ttid.d.ts
@@ -1,21 +1,44 @@
-type _ttid = string | `${string}-${string}` | `${string}-${string}-${string}`
+export type _ttid = string | `${string}-${string}` | `${string}-${string}-${string}`
 
-interface _timestamps {
-    createdAt: number,
-    updatedAt?: number,
+export interface _timestamps {
+    createdAt: number
+    updatedAt?: number
     deletedAt?: number
 }
 
 declare module "@vyckr/ttid" {
 
-    export default class {
+    export default class TTID {
 
-        static isTTID(_id: string): RegExpMatchArray | Date | null
+        /**
+         * Checks whether a string is a valid TTID.
+         * @param _id - The string to validate.
+         * @returns The creation `Date` if valid, or `null` if not.
+         */
+        static isTTID(_id: string): Date | null
 
+        /**
+         * Checks whether a string is a valid UUID (any version or variant).
+         * @param _id - The string to validate.
+         * @returns A `RegExpMatchArray` if valid, or `null` if not.
+         */
         static isUUID(_id: string): RegExpMatchArray | null
 
+        /**
+         * Generates a new TTID or advances an existing one through its lifecycle.
+         * @param _id - An existing TTID to update or delete. Omit to create a new one.
+         * @param del - When `true`, marks the TTID as deleted.
+         * @returns The new or advanced TTID.
+         * @throws {Error} If `_id` is already deleted or is not a valid TTID.
+         */
         static generate(_id?: string, del?: boolean): _ttid
 
-        static decodeTime(_id: string): { createdAt: number, updatedAt: number }
+        /**
+         * Decodes the timestamps embedded in a TTID.
+         * @param _id - A valid TTID string.
+         * @returns An object with `createdAt`, and optionally `updatedAt` and `deletedAt` (ms since epoch).
+         * @throws {Error} If the format is invalid or any segment encodes an out-of-range timestamp.
+         */
+        static decodeTime(_id: string): _timestamps
     }
 }

--- a/test/ttid.test.ts
+++ b/test/ttid.test.ts
@@ -3,6 +3,8 @@ import { test, expect, describe } from 'bun:test'
 
 describe("TTID", () => {
 
+    // ─── Lifecycle integration tests ────────────────────────────────────────────
+
     test("Generate", () => {
 
         const _id = TTID.generate()
@@ -11,7 +13,7 @@ describe("TTID", () => {
 
         const { createdAt } = TTID.decodeTime(_id)
 
-        expect(TTID.isTTID(_id)).toBeTrue()
+        expect(TTID.isTTID(_id)).toBeInstanceOf(Date)
         expect(TTID.isUUID(_id)).toBeNull()
         expect(TTID.isUUID(Bun.randomUUIDv7())).not.toBeNull()
         expect(typeof createdAt).toBe('number')
@@ -31,7 +33,7 @@ describe("TTID", () => {
 
         expect(updated).not.toBeUndefined()
         expect(created).not.toEqual(updated)
-        expect(TTID.isTTID(_newId)).toBeTrue()
+        expect(TTID.isTTID(_newId)).toBeInstanceOf(Date)
         expect(TTID.isUUID(_newId)).toBeNull()
         expect(_id).not.toEqual(_newId)
         expect(typeof createdAt).toBe('number')
@@ -56,7 +58,7 @@ describe("TTID", () => {
         expect(updated).toEqual('X')
         expect(deleted).not.toBeUndefined()
         expect(created).not.toEqual(deleted)
-        expect(TTID.isTTID(_newId)).toBeTrue()
+        expect(TTID.isTTID(_newId)).toBeInstanceOf(Date)
         expect(TTID.isUUID(_newId)).toBeNull()
         expect(_id).not.toEqual(_newId)
         expect(typeof createdAt).toBe('number')
@@ -80,13 +82,13 @@ describe("TTID", () => {
         const [created, updated, deleted] = _deletedId.split('-')
 
         const { createdAt, updatedAt, deletedAt } = TTID.decodeTime(_deletedId)
-        
+
         expect(updated).not.toEqual('X')
         expect(deleted).not.toBeUndefined()
         expect(created).not.toEqual(deleted)
         expect(created).not.toEqual(updated)
         expect(updated).not.toEqual(deleted)
-        expect(TTID.isTTID(_newId)).toBeTrue()
+        expect(TTID.isTTID(_newId)).toBeInstanceOf(Date)
         expect(TTID.isUUID(_newId)).toBeNull()
         expect(_id).not.toEqual(_newId)
         expect(_newId).not.toEqual(_deletedId)
@@ -100,5 +102,244 @@ describe("TTID", () => {
         expect(deletedAt).not.toBeUndefined()
         expect(deletedAt).toBeGreaterThan(createdAt)
         expect(updatedAt).toBeGreaterThan(createdAt)
+    })
+
+    // ─── generate() ─────────────────────────────────────────────────────────────
+
+    describe('generate()', () => {
+
+        test('Updated-Deleted: 2-segment + del:true produces 3-segment without placeholder', async () => {
+
+            const _id = TTID.generate()
+            await Bun.sleep(100)
+            const _updatedId = TTID.generate(_id)
+            await Bun.sleep(100)
+            const _deletedId = TTID.generate(_updatedId, true)
+
+            const [, updated, deleted] = _deletedId.split('-')
+
+            expect(updated).not.toEqual('X')
+            expect(deleted).not.toBeUndefined()
+            expect(_deletedId.split('-')).toHaveLength(3)
+            expect(TTID.isTTID(_deletedId)).toBeInstanceOf(Date)
+        })
+
+        test('del:false explicitly behaves the same as omitting the flag', () => {
+
+            const _id = TTID.generate()
+            const _updated = TTID.generate(_id, false)
+
+            expect(_updated.split('-')).toHaveLength(2)
+        })
+
+        test('throws when given a UUID string', () => {
+
+            expect(() => TTID.generate(Bun.randomUUIDv7())).toThrow('Invalid TTID!')
+        })
+
+        test('throws when attempting to modify a deleted TTID', () => {
+
+            const _id = TTID.generate()
+            const _deletedId = TTID.generate(_id, true)
+
+            expect(() => TTID.generate(_deletedId)).toThrow('This identifier can no longer be modified')
+            expect(() => TTID.generate(_deletedId, true)).toThrow('This identifier can no longer be modified')
+        })
+
+        test('throws when given an invalid TTID string', () => {
+
+            expect(() => TTID.generate('not-a-valid-ttid')).toThrow('Invalid TTID!')
+        })
+
+        test('successive calls produce unique IDs', async () => {
+
+            const ids: string[] = []
+            for (let i = 0; i < 5; i++) {
+                await Bun.sleep(1)
+                ids.push(TTID.generate())
+            }
+
+            expect(new Set(ids).size).toBe(ids.length)
+        })
+    })
+
+    // ─── isTTID() ────────────────────────────────────────────────────────────────
+
+    describe('isTTID()', () => {
+
+        test('empty string returns null', () => {
+
+            expect(TTID.isTTID('')).toBeNull()
+        })
+
+        test('1-segment TTID returns creation Date', () => {
+
+            const _id = TTID.generate()
+            expect(TTID.isTTID(_id)).toBeInstanceOf(Date)
+        })
+
+        test('2-segment TTID returns creation Date, not the update timestamp', async () => {
+
+            const _id = TTID.generate()
+            await Bun.sleep(100)
+            const _updatedId = TTID.generate(_id)
+
+            const result = TTID.isTTID(_updatedId)
+            const { createdAt } = TTID.decodeTime(_updatedId)
+
+            expect(result).toBeInstanceOf(Date)
+            expect(result?.getTime()).toBe(createdAt)
+        })
+
+        test('3-segment TTID returns creation Date, not the deletion timestamp', async () => {
+
+            const _id = TTID.generate()
+            await Bun.sleep(100)
+            const _deletedId = TTID.generate(_id, true)
+
+            const result = TTID.isTTID(_deletedId)
+            const { createdAt } = TTID.decodeTime(_deletedId)
+
+            expect(result).toBeInstanceOf(Date)
+            expect(result?.getTime()).toBe(createdAt)
+        })
+
+        test('valid-format but out-of-range timestamp returns null', () => {
+
+            expect(TTID.isTTID('00000000000')).toBeNull()
+        })
+
+        test('UUID string returns null', () => {
+
+            expect(TTID.isTTID(Bun.randomUUIDv7())).toBeNull()
+        })
+    })
+
+    // ─── decodeTime() ────────────────────────────────────────────────────────────
+
+    describe('decodeTime()', () => {
+
+        test('1-segment TTID has only createdAt defined', () => {
+
+            const { createdAt, updatedAt, deletedAt } = TTID.decodeTime(TTID.generate())
+
+            expect(typeof createdAt).toBe('number')
+            expect(updatedAt).toBeUndefined()
+            expect(deletedAt).toBeUndefined()
+        })
+
+        test('2-segment TTID has updatedAt defined and deletedAt undefined', () => {
+
+            const _id = TTID.generate()
+            const { updatedAt, deletedAt } = TTID.decodeTime(TTID.generate(_id))
+
+            expect(updatedAt).not.toBeUndefined()
+            expect(deletedAt).toBeUndefined()
+        })
+
+        test('3-segment TTID with placeholder has updatedAt undefined and deletedAt defined', async () => {
+
+            const _id = TTID.generate()
+            await Bun.sleep(100)
+            const _deletedId = TTID.generate(_id, true)
+            const { updatedAt, deletedAt } = TTID.decodeTime(_deletedId)
+
+            expect(updatedAt).toBeUndefined()
+            expect(deletedAt).not.toBeUndefined()
+        })
+
+        test('timestamps are in chronological order across the full lifecycle', async () => {
+
+            const _id = TTID.generate()
+            await Bun.sleep(100)
+            const _updatedId = TTID.generate(_id)
+            await Bun.sleep(100)
+            const _deletedId = TTID.generate(_updatedId, true)
+
+            const { createdAt, updatedAt, deletedAt } = TTID.decodeTime(_deletedId)
+
+            expect(updatedAt).toBeGreaterThan(createdAt)
+            expect(deletedAt).toBeGreaterThan(updatedAt!)
+        })
+
+        test('throws on invalid format', () => {
+
+            expect(() => TTID.decodeTime('not-a-valid-ttid')).toThrow('Invalid Format!')
+        })
+
+        test('throws on out-of-range timestamp segment', () => {
+
+            expect(() => TTID.decodeTime('00000000000')).toThrow('Timestamp out of valid range')
+        })
+    })
+
+    // ─── Output format ───────────────────────────────────────────────────────────
+
+    describe('output format', () => {
+
+        test('generated IDs are always uppercase', () => {
+
+            const _id = TTID.generate()
+            expect(_id).toBe(_id.toUpperCase())
+        })
+
+        test('single-segment ID is exactly 11 characters', () => {
+
+            expect(TTID.generate()).toHaveLength(11)
+        })
+
+        test('two-segment ID has two 11-character segments', () => {
+
+            const _id = TTID.generate()
+            const [created, updated] = TTID.generate(_id).split('-')
+
+            expect(created).toHaveLength(11)
+            expect(updated).toHaveLength(11)
+        })
+
+        test('three-segment ID (with placeholder) has correct segment lengths', async () => {
+
+            const _id = TTID.generate()
+            await Bun.sleep(100)
+            const [created, placeholder, deleted] = TTID.generate(_id, true).split('-')
+
+            expect(created).toHaveLength(11)
+            expect(placeholder).toBe('X')
+            expect(deleted).toHaveLength(11)
+        })
+
+        test('isTTID Date.getTime() is consistent with decodeTime createdAt', () => {
+
+            const _id = TTID.generate()
+            const date = TTID.isTTID(_id)
+            const { createdAt } = TTID.decodeTime(_id)
+
+            expect(date?.getTime()).toBe(createdAt)
+        })
+    })
+
+    // ─── isUUID() ────────────────────────────────────────────────────────────────
+
+    describe('isUUID()', () => {
+
+        test('TTID returns null', () => {
+
+            expect(TTID.isUUID(TTID.generate())).toBeNull()
+        })
+
+        test('valid UUID v4 returns a match', () => {
+
+            expect(TTID.isUUID('550e8400-e29b-41d4-a716-446655440000')).not.toBeNull()
+        })
+
+        test('valid UUID v7 returns a match', () => {
+
+            expect(TTID.isUUID(Bun.randomUUIDv7())).not.toBeNull()
+        })
+
+        test('empty string returns null', () => {
+
+            expect(TTID.isUUID('')).toBeNull()
+        })
     })
 })


### PR DESCRIPTION
## Summary
- Improved type safety: `isTTID` return type narrowed to `Date | null`, `decodeTime` return type corrected with optional fields
- Cached regex patterns as `private static readonly` to avoid recompilation
- Added input bounds validation in `decodeTime` (timestamps must fall within 2020–2200)
- Documented all magic constants and public methods with JSDoc
- Fixed typo: `identifer` → `identifier` in error message and package keywords
- Exported `_ttid` and `_timestamps` types from the module declaration for named consumer imports
- Expanded test suite from 8 to 31 tests covering error paths, output format, and all method edge cases
- Added ESLint + Prettier config and CI/publish GitHub Actions workflows
- Added Claude slash commands: `/issue`, `/pr`, `/release`, `/review-pr`, `/sync-main`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 31 tests pass across all lifecycle and edge-case scenarios

## Breaking changes
None