### PR TITLE
fix: release v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,21 @@ TTIDs follow a strict format:
 - High-resolution timestamps ensure uniqueness in high-frequency scenarios
 - Validation includes timestamp parsing for integrity checking
 
+## Security
+
+`_ttid` is a TypeScript template-literal type, not a runtime-enforced brand. TypeScript alone cannot prevent a plain `string` from being used where a `_ttid` is expected.
+
+**Rule:** always obtain TTID values via `TTID.generate()` or validate them with `TTID.isTTID()` before using them in any security-sensitive context (database keys, access-control checks, audit logs).
+
+```typescript
+const raw: string = externalInput()
+const valid = TTID.isTTID(raw)   // returns Date | null
+if (!valid) throw new Error('Invalid identifier')
+// safe to use raw as _ttid from here
+```
+
+Input length is bounded to 36 characters before any regex evaluation, preventing CPU exhaustion from pathological inputs.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyckr/ttid",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "./src/index.ts",
   "types": "./src/types/index.d.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ export default class TTID {
      */
     static isTTID(_id: string): Date | null {
 
+        if (!_id || _id.length > 36) return null
+
         if (!this.TTID_PATTERN.test(_id)) return null
 
         try {
@@ -121,7 +123,7 @@ export default class TTID {
             const ms = Number((parseInt(timeCode, this.BASE) / this.PRECISION).toFixed(0))
 
             if (!isFinite(ms) || ms < this.MIN_TIMESTAMP_MS || ms > this.MAX_TIMESTAMP_MS) {
-                throw new Error(`Timestamp out of valid range in segment: ${timeCode}`)
+                throw new Error('Invalid timestamp encoding')
             }
 
             return ms

--- a/test/ttid.test.ts
+++ b/test/ttid.test.ts
@@ -213,6 +213,11 @@ describe("TTID", () => {
 
             expect(TTID.isTTID(Bun.randomUUIDv7())).toBeNull()
         })
+
+        test('rejects oversized input without regex evaluation', () => {
+
+            expect(TTID.isTTID('A'.repeat(37))).toBeNull()
+        })
     })
 
     // ─── decodeTime() ────────────────────────────────────────────────────────────
@@ -269,7 +274,7 @@ describe("TTID", () => {
 
         test('throws on out-of-range timestamp segment', () => {
 
-            expect(() => TTID.decodeTime('00000000000')).toThrow('Timestamp out of valid range')
+            expect(() => TTID.decodeTime('00000000000')).toThrow('Invalid timestamp encoding')
         })
     })
 


### PR DESCRIPTION
## Summary

- Harden `isTTID`: add 36-char length guard before regex evaluation (I-M2/I-L1 — prevents CPU exhaustion from oversized inputs)
- Sanitise `decodeTime` error message: no longer reflects raw timeCode segment back to caller (I-M1 — information disclosure fix)
- Add Security section to README documenting `_ttid` validation requirements (I-L3)

## Test plan

- [x] All 32 existing tests pass
- [x] New test: `rejects oversized input without regex evaluation`
- [x] Updated test: `throws on out-of-range timestamp segment` expects `'Invalid timestamp encoding'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)