### PR TITLE
Release v1.3.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,13 +58,13 @@ jobs:
           fi
 
   publish:
-    name: Publish to npm
+    name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: [test, version]
     if: needs.version.outputs.tag_exists == 'false'
     permissions:
       contents: read
-      id-token: write   # npm provenance
+      packages: write
 
     steps:
       - name: Checkout
@@ -78,18 +78,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Setup Node and upgrade npm
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@d31ma'
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-
-      - name: Publish to npm (Trusted Publishing via OIDC)
-        run: |
-          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-          npm publish --access public --provenance
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   github-release:
     name: Create GitHub release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@d31ma:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ Each TTID segment contains:
 
 ## Installation
 
+Authenticate with GitHub Packages before installing:
+
+```bash
+npm login --scope=@d31ma --auth-type=legacy --registry=https://npm.pkg.github.com
+```
+
+Then add this to your user or project `.npmrc`:
+
+```ini
+@d31ma:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+```
+
+See GitHub's npm registry docs for the latest authentication details:
+https://docs.github.com/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages
+
 ```bash
 npm install @d31ma/ttid
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each TTID segment contains:
 ## Installation
 
 ```bash
-npm install @delma/ttid
+npm install @d31ma/ttid
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ npm install @delma/ttid
 ### Basic ID Generation
 
 ```typescript
-import TTID from '@delma/ttid';
+import TTID from '@d31ma/ttid';
 
 // Generate a new TTID (creation only)
 const newId = TTID.generate();
@@ -41,7 +41,7 @@ console.log(isValid); // Returns Date object if valid, null if invalid
 ### Progressive Updates
 
 ```typescript
-import TTID from '@delma/ttid';
+import TTID from '@d31ma/ttid';
 
 // Start with a new ID
 let id = TTID.generate();
@@ -70,7 +70,7 @@ try {
 ### Decoding Timestamps
 
 ```typescript
-import TTID from '@delma/ttid';
+import TTID from '@d31ma/ttid';
 
 // Create and update an ID
 let id = TTID.generate();
@@ -104,7 +104,7 @@ setTimeout(() => {
 ### Working with Different States
 
 ```typescript
-import TTID from '@delma/ttid';
+import TTID from '@d31ma/ttid';
 
 // Check ID states
 function analyzeId(id: string) {
@@ -153,7 +153,7 @@ analyzeId(deletedId); // ID State: Deleted
 ### Error Handling
 
 ```typescript
-import TTID from '@delma/ttid';
+import TTID from '@d31ma/ttid';
 
 // Invalid ID format
 try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@delma/ttid",
-  "version": "1.3.6",
+  "name": "@d31ma/ttid",
+  "version": "1.3.7",
   "main": "./src/index.ts",
   "types": "./src/types/index.d.ts",
   "scripts": {
@@ -25,6 +25,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/d31ma/TTID.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   },
   "license": "MIT",
   "keywords": [

--- a/src/types/ttid.d.ts
+++ b/src/types/ttid.d.ts
@@ -1,4 +1,4 @@
-declare module "@delma/ttid" {
+declare module "@d31ma/ttid" {
 
     /** Branded string type representing a TTID in one of its three lifecycle states. */
     export type _ttid = string | `${string}-${string}` | `${string}-${string}-${string}`
@@ -46,5 +46,5 @@ declare module "@delma/ttid" {
 }
 
 // Global ambient aliases so src/index.ts can reference these types without an import.
-type _ttid = import("@delma/ttid")._ttid
-type _timestamps = import("@delma/ttid")._timestamps
+type _ttid = import("@d31ma/ttid")._ttid
+type _timestamps = import("@d31ma/ttid")._timestamps


### PR DESCRIPTION
Release PR for v1.3.7.

This release switches TTID publishing to GitHub Packages as `@d31ma/ttid`, updates README/type declarations to the new package name, and wires the publish workflow to GitHub Packages.

Validation run locally:
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `npm publish --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package scope updated to @d31ma/ttid (from @delma/ttid)
  * Package now published to GitHub Packages instead of npm
  * Installation and import statements updated in documentation
  * Version bumped to 1.3.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->