### PR TITLE
Release TTID 1.3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,4 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-          if [ -f package.json ] && jq -e '.scripts["blackbox:ttid"]' package.json >/dev/null; then
-            bun run blackbox:ttid
-          elif [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
-            bun run blackbox
-          else
-            bun test ./ttid --timeout 120000
-          fi
+          bun test ./ttid --timeout 120000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: bun run lint
 
       - name: Run tests
-        run: bun test
+        run: bun test --isolate --parallel
 
   blackbox-config:
     name: Detect blackbox configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
     outputs:
       enabled: ${{ steps.detect.outputs.enabled }}
     env:
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
 
     steps:
       - id: detect
@@ -73,8 +73,8 @@ jobs:
     timeout-minutes: 20
     env:
       TTID_PACKAGE_TARBALL: /tmp/ttid-blackbox.tgz
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
 
     steps:
       - name: Checkout TTID
@@ -94,11 +94,11 @@ jobs:
       - name: Require private blackbox credentials
         run: |
           if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_REPOSITORY/NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
+            echo "::error::Missing TTID_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
             exit 1
           fi
           if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_SSH_KEY or NIGHTJAR_BLACKBOX_SSH_KEY secret"
+            echo "::error::Missing TTID_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
             exit 1
           fi
 
@@ -107,7 +107,7 @@ jobs:
         with:
           repository: ${{ env.BLACKBOX_REPOSITORY }}
           ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TTID_BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
+          ref: ${{ vars.TTID_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
           path: .blackbox-tests
 
       - name: Run TTID blackbox tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,27 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test (Bun ${{ matrix.bun-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
+      fail-fast: false
       matrix:
         bun-version: [latest, 1.2.x]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -35,3 +44,84 @@ jobs:
 
       - name: Run tests
         run: bun test
+
+  blackbox-config:
+    name: Detect blackbox configuration
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.detect.outputs.enabled }}
+    env:
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+
+    steps:
+      - id: detect
+        name: Check private suite credentials
+        run: |
+          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Blackbox configuration not present; skipping private package validation."
+          fi
+
+  package-blackbox:
+    name: Package blackbox tests
+    runs-on: ubuntu-latest
+    needs: blackbox-config
+    if: needs.blackbox-config.outputs.enabled == 'true'
+    timeout-minutes: 20
+    env:
+      TTID_PACKAGE_TARBALL: /tmp/ttid-blackbox.tgz
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+
+    steps:
+      - name: Checkout TTID
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Pack package under test
+        run: bun pm pack --filename "$TTID_PACKAGE_TARBALL" --quiet
+
+      - name: Require private blackbox credentials
+        run: |
+          if [ -z "$BLACKBOX_REPOSITORY" ]; then
+            echo "::error::Missing TTID_BLACKBOX_REPOSITORY/NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
+            exit 1
+          fi
+          if [ -z "$BLACKBOX_SSH_KEY" ]; then
+            echo "::error::Missing TTID_BLACKBOX_SSH_KEY or NIGHTJAR_BLACKBOX_SSH_KEY secret"
+            exit 1
+          fi
+
+      - name: Checkout private blackbox suite
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BLACKBOX_REPOSITORY }}
+          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
+          ref: ${{ vars.TTID_BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
+          path: .blackbox-tests
+
+      - name: Run TTID blackbox tests
+        working-directory: .blackbox-tests
+        env:
+          NIGHTJAR_SUITE: ttid
+          TTID_PACKAGE_TARBALL: ${{ env.TTID_PACKAGE_TARBALL }}
+        run: |
+          if [ -f package.json ] || [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile
+          fi
+
+          if [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
+            bun run blackbox
+          else
+            bun test ttid --timeout 120000
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,10 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-          if [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
+          if [ -f package.json ] && jq -e '.scripts["blackbox:ttid"]' package.json >/dev/null; then
+            bun run blackbox:ttid
+          elif [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
             bun run blackbox
           else
-            bun test ttid --timeout 120000
+            bun test ./ttid --timeout 120000
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,4 +120,4 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-          bun test ./ttid --timeout 120000
+          bun test ttid/*.test.mjs --timeout 120000

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,8 @@ jobs:
     outputs:
       enabled: ${{ steps.detect.outputs.enabled }}
     env:
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
 
     steps:
       - id: detect
@@ -67,8 +67,8 @@ jobs:
     timeout-minutes: 20
     env:
       TTID_PACKAGE_TARBALL: /tmp/ttid-blackbox.tgz
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
 
     steps:
       - name: Checkout TTID
@@ -88,11 +88,11 @@ jobs:
       - name: Require private blackbox credentials
         run: |
           if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_REPOSITORY/NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
+            echo "::error::Missing TTID_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
             exit 1
           fi
           if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_SSH_KEY or NIGHTJAR_BLACKBOX_SSH_KEY secret"
+            echo "::error::Missing TTID_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
             exit 1
           fi
 
@@ -101,7 +101,7 @@ jobs:
         with:
           repository: ${{ env.BLACKBOX_REPOSITORY }}
           ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TTID_BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
+          ref: ${{ vars.TTID_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
           path: .blackbox-tests
 
       - name: Run TTID blackbox tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         run: bun run lint
 
       - name: Run tests
-        run: bun test
+        run: bun test --isolate --parallel
 
   blackbox-config:
     name: Detect blackbox configuration

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-          bun test ./ttid --timeout 120000
+          bun test ttid/*.test.mjs --timeout 120000
 
   version:
     name: Read version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,13 +114,7 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-          if [ -f package.json ] && jq -e '.scripts["blackbox:ttid"]' package.json >/dev/null; then
-            bun run blackbox:ttid
-          elif [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
-            bun run blackbox
-          else
-            bun test ./ttid --timeout 120000
-          fi
+          bun test ./ttid --timeout 120000
 
   version:
     name: Read version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,22 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Test before publish
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -22,19 +30,107 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
       - name: Run tests
         run: bun test
+
+  blackbox-config:
+    name: Detect blackbox configuration
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.detect.outputs.enabled }}
+    env:
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+
+    steps:
+      - id: detect
+        name: Check private suite credentials
+        run: |
+          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Blackbox configuration not present; skipping private package validation."
+          fi
+
+  package-blackbox:
+    name: Package blackbox tests
+    runs-on: ubuntu-latest
+    needs: blackbox-config
+    if: needs.blackbox-config.outputs.enabled == 'true'
+    timeout-minutes: 20
+    env:
+      TTID_PACKAGE_TARBALL: /tmp/ttid-blackbox.tgz
+      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+
+    steps:
+      - name: Checkout TTID
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Pack package under test
+        run: bun pm pack --filename "$TTID_PACKAGE_TARBALL" --quiet
+
+      - name: Require private blackbox credentials
+        run: |
+          if [ -z "$BLACKBOX_REPOSITORY" ]; then
+            echo "::error::Missing TTID_BLACKBOX_REPOSITORY/NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
+            exit 1
+          fi
+          if [ -z "$BLACKBOX_SSH_KEY" ]; then
+            echo "::error::Missing TTID_BLACKBOX_SSH_KEY or NIGHTJAR_BLACKBOX_SSH_KEY secret"
+            exit 1
+          fi
+
+      - name: Checkout private blackbox suite
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BLACKBOX_REPOSITORY }}
+          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
+          ref: ${{ vars.TTID_BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
+          path: .blackbox-tests
+
+      - name: Run TTID blackbox tests
+        working-directory: .blackbox-tests
+        env:
+          NIGHTJAR_SUITE: ttid
+          TTID_PACKAGE_TARBALL: ${{ env.TTID_PACKAGE_TARBALL }}
+        run: |
+          if [ -f package.json ] || [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile
+          fi
+
+          if [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
+            bun run blackbox
+          else
+            bun test ttid --timeout 120000
+          fi
 
   version:
     name: Read version
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.read.outputs.version }}
       tag_exists: ${{ steps.check.outputs.exists }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -60,15 +156,17 @@ jobs:
   publish:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: [test, version]
-    if: needs.version.outputs.tag_exists == 'false'
+    needs: [test, blackbox-config, package-blackbox, version]
+    if: needs.version.outputs.tag_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
+    environment: packages-prod
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -79,9 +177,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@d31ma'
 
@@ -95,12 +193,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [version, publish]
     if: needs.version.outputs.tag_exists == 'false'
+    timeout-minutes: 10
     permissions:
       contents: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,10 +114,12 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-          if [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
+          if [ -f package.json ] && jq -e '.scripts["blackbox:ttid"]' package.json >/dev/null; then
+            bun run blackbox:ttid
+          elif [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
             bun run blackbox
           else
-            bun test ttid --timeout 120000
+            bun test ./ttid --timeout 120000
           fi
 
   version:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d31ma/ttid",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "./src/index.ts",
   "types": "./src/types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump `@d31ma/ttid` from `1.3.7` to `1.3.8`
- keep the hardened CI/CD baseline from this branch and update Bun test execution to use `--isolate --parallel`
- preserve the GitHub Packages publish flow and blackbox validation already staged on this PR

## Why
This turns the existing CI/CD hardening work into a shippable patch release instead of leaving the publish path and version unchanged on merge.

## Validation
- local `bun test --isolate --parallel`
- existing PR CI will rerun on the updated head commit

## Release Notes
- faster Bun test execution in CI and publish checks
- no intended API changes