### PR TITLE
Release TTID 26.18.27-1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,10 +184,44 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-npm:
+    name: Publish to npm registry
+    runs-on: ubuntu-latest
+    needs: [test, blackbox-config, package-blackbox, version]
+    if: needs.version.outputs.tag_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    environment: packages-prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@d31ma'
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
-    needs: [version, publish]
+    needs: [version, publish, publish-npm]
     if: needs.version.outputs.tag_exists == 'false'
     timeout-minutes: 10
     permissions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d31ma/ttid",
-  "version": "26.18.27",
+  "version": "26.18.27-1",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Release TTID 26.18.27-1

### Changes
- Add dual-publish to npm registry alongside GitHub Packages
- Bump version to 26.18.27-1

### Verification
- All 32 tests pass
- Typecheck passes
- No open issues