### PR TITLE
ci: fix npm publish for CalVer versions with dash suffixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,7 +180,7 @@ jobs:
           scope: '@d31ma'
 
       - name: Publish to GitHub Packages
-        run: npm publish
+        run: npm publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -214,7 +214,7 @@ jobs:
           scope: '@d31ma'
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Fix npm publish error: You must specify a tag using --tag when publishing a prerelease version.