### PR TITLE
Use FOUNDRY for npm promotion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: release-${{ github.repository }}
@@ -121,8 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
+      package_name: ${{ steps.read.outputs.package_name }}
       version: ${{ steps.read.outputs.version }}
       tag_exists: ${{ steps.check.outputs.exists }}
+      github_version_exists: ${{ steps.check_github.outputs.exists }}
+      npm_version_exists: ${{ steps.check_npm.outputs.exists }}
 
     steps:
       - name: Checkout
@@ -133,8 +137,11 @@ jobs:
       - name: Read package version
         id: read
         run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
+          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Package: $PACKAGE_NAME"
           echo "Version: $VERSION"
 
       - name: Check version tag
@@ -149,11 +156,44 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check GitHub Packages version
+        id: check_github
+        env:
+          PACKAGE_NAME: ${{ steps.read.outputs.package_name }}
+          VERSION: ${{ steps.read.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > ~/.npmrc <<EOF
+          @d31ma:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          always-auth=true
+          EOF
+
+          if npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub Packages already has ${PACKAGE_NAME}@${VERSION}."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check npm version
+        id: check_npm
+        env:
+          PACKAGE_NAME: ${{ steps.read.outputs.package_name }}
+          VERSION: ${{ steps.read.outputs.version }}
+        run: |
+          if npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "npm already has ${PACKAGE_NAME}@${VERSION}."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
   publish:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: [test, blackbox-config, package-blackbox, version]
-    if: needs.version.outputs.tag_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    if: needs.version.outputs.tag_exists == 'false' && needs.version.outputs.github_version_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
     timeout-minutes: 15
     permissions:
       contents: read
@@ -180,48 +220,31 @@ jobs:
           scope: '@d31ma'
 
       - name: Publish to GitHub Packages
-        run: npm publish --tag latest
+        run: npm publish --tag beta --registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-npm:
-    name: Publish to npm registry
-    runs-on: ubuntu-latest
-    needs: [test, blackbox-config, package-blackbox, version]
-    if: needs.version.outputs.tag_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
-    timeout-minutes: 15
+  promote-npm:
+    name: Promote to npm registry
+    needs: [version, publish]
+    if: needs.publish.result == 'success'
     permissions:
       contents: read
-    environment: packages-prod
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@d31ma'
-
-      - name: Publish to npm
-        run: rm -f .npmrc && npm publish --access public --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      packages: read
+    uses: d31ma/FOUNDRY/.github/workflows/promote-npm.yml@main
+    with:
+      package_name: ${{ needs.version.outputs.package_name }}
+      version: ${{ needs.version.outputs.version }}
+      npm_dist_tag: latest
+      source_repository: ${{ github.repository }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      PACKAGES_READ_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
 
   github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
-    needs: [version, publish, publish-npm]
+    needs: [version, publish, promote-npm]
     if: needs.version.outputs.tag_exists == 'false'
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary
- replace the inline npm publish job with the central FOUNDRY reusable workflow
- promote the exact GitHub Packages version to npm after the GitHub Packages publish succeeds
- keep GitHub release creation behind package promotion

## Validation
- YAML parsed locally for this repo's publish workflow
- FOUNDRY reusable workflow is available at d31ma/FOUNDRY/.github/workflows/promote-npm.yml@main