### PR TITLE
Use FOUNDRY for GitHub Packages publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,9 +191,9 @@ jobs:
 
   publish:
     name: Publish to GitHub Packages
-    runs-on: ubuntu-latest
     needs: [test, blackbox-config, package-blackbox, version]
     if: needs.version.outputs.tag_exists == 'false' && needs.version.outputs.github_version_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
@@ -201,28 +201,14 @@ jobs:
     environment: packages-prod
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Publish via FOUNDRY
+        uses: d31ma/FOUNDRY/.github/actions/publish-github-package@main
         with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@d31ma'
-
-      - name: Publish to GitHub Packages
-        run: npm publish --tag beta --registry=https://npm.pkg.github.com
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          package_name: ${{ needs.version.outputs.package_name }}
+          version: ${{ needs.version.outputs.version }}
+          github_dist_tag: beta
+          publish_token: ${{ github.token }}
+          packages_read_token: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
 
   promote-npm:
     name: Promote to npm registry


### PR DESCRIPTION
## Summary\n- replace the inline GitHub Packages publish steps with the shared FOUNDRY publish action\n- keep repo-local validation, blackbox gating, packages-prod environment, and npm promotion flow intact\n\n## Verification\n- ruby YAML parse for .github/workflows/publish.yml