### PR TITLE
Use OIDC for npm promotion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,6 +216,7 @@ jobs:
     if: needs.publish.result == 'success'
     permissions:
       contents: read
+      id-token: write
       packages: read
     uses: d31ma/FOUNDRY/.github/workflows/promote-npm.yml@main
     with:
@@ -224,7 +225,6 @@ jobs:
       npm_dist_tag: latest
       source_repository: ${{ github.repository }}
     secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PACKAGES_READ_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
 
   github-release:


### PR DESCRIPTION
## Summary\n- grant id-token: write for the FOUNDRY npm promotion job\n- stop passing NPM_TOKEN to FOUNDRY\n\n## Verification\n- ruby YAML parse for .github/workflows/publish.yml