### PR TITLE
Release 26.21.03

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [release/*]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -15,69 +14,12 @@ concurrency:
 
 jobs:
   test:
-    name: Test (Bun ${{ matrix.bun-version }})
+    name: Test (Bun latest)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    strategy:
-      fail-fast: false
-      matrix:
-        bun-version: [latest, 1.2.x]
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ matrix.bun-version }}
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Lint
-        run: bun run lint
-
-      - name: Run tests
-        run: bun test --isolate --parallel
-
-  blackbox-config:
-    name: Detect blackbox configuration
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.detect.outputs.enabled }}
-    env:
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - id: detect
-        name: Check private suite credentials
-        run: |
-          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Blackbox configuration not present; skipping private package validation."
-          fi
-
-  package-blackbox:
-    name: Package blackbox tests
-    runs-on: ubuntu-latest
-    needs: blackbox-config
-    if: needs.blackbox-config.outputs.enabled == 'true'
-    timeout-minutes: 20
-    env:
-      TTID_PACKAGE_TARBALL: /tmp/ttid-blackbox.tgz
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - name: Checkout TTID
         uses: actions/checkout@v6
 
       - name: Setup Bun
@@ -88,36 +30,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Pack package under test
-        run: bun pm pack --filename "$TTID_PACKAGE_TARBALL" --quiet
+      - name: Type check
+        run: bun run typecheck
 
-      - name: Require private blackbox credentials
-        run: |
-          if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
-            exit 1
-          fi
-          if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
-            exit 1
-          fi
-
-      - name: Checkout private blackbox suite
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TTID_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
-          path: .blackbox-tests
-
-      - name: Run TTID blackbox tests
-        working-directory: .blackbox-tests
-        env:
-          NIGHTJAR_SUITE: ttid
-          TTID_PACKAGE_TARBALL: ${{ env.TTID_PACKAGE_TARBALL }}
-        run: |
-          if [ -f package.json ] || [ -f bun.lock ] || [ -f bun.lockb ]; then
-            bun install --frozen-lockfile
-          fi
-
-          bun test ttid/*.test.mjs --timeout 120000
+      - name: Run tests
+        run: bun test ./test/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,88 +34,8 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
-      - name: Lint
-        run: bun run lint
-
       - name: Run tests
-        run: bun test --isolate --parallel
-
-  blackbox-config:
-    name: Detect blackbox configuration
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.detect.outputs.enabled }}
-    env:
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - id: detect
-        name: Check private suite credentials
-        run: |
-          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Blackbox configuration not present; skipping private package validation."
-          fi
-
-  package-blackbox:
-    name: Package blackbox tests
-    runs-on: ubuntu-latest
-    needs: blackbox-config
-    if: needs.blackbox-config.outputs.enabled == 'true'
-    timeout-minutes: 20
-    env:
-      TTID_PACKAGE_TARBALL: /tmp/ttid-blackbox.tgz
-      BLACKBOX_REPOSITORY: ${{ vars.TTID_BLACKBOX_REPOSITORY || secrets.TTID_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TTID_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - name: Checkout TTID
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Pack package under test
-        run: bun pm pack --filename "$TTID_PACKAGE_TARBALL" --quiet
-
-      - name: Require private blackbox credentials
-        run: |
-          if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
-            exit 1
-          fi
-          if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TTID_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
-            exit 1
-          fi
-
-      - name: Checkout private blackbox suite
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TTID_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
-          path: .blackbox-tests
-
-      - name: Run TTID blackbox tests
-        working-directory: .blackbox-tests
-        env:
-          NIGHTJAR_SUITE: ttid
-          TTID_PACKAGE_TARBALL: ${{ env.TTID_PACKAGE_TARBALL }}
-        run: |
-          if [ -f package.json ] || [ -f bun.lock ] || [ -f bun.lockb ]; then
-            bun install --frozen-lockfile
-          fi
-
-          bun test ttid/*.test.mjs --timeout 120000
+        run: bun test ./test/
 
   version:
     name: Read version
@@ -163,13 +83,13 @@ jobs:
           VERSION: ${{ steps.read.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat > ~/.npmrc <<EOF
-          @d31ma:registry=https://npm.pkg.github.com
-          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-          always-auth=true
-          EOF
+          {
+            echo "@d31ma:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
+            echo "always-auth=true"
+          } > "$RUNNER_TEMP/gh-packages.npmrc"
 
-          if npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+          if NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/gh-packages.npmrc" npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "GitHub Packages already has ${PACKAGE_NAME}@${VERSION}."
           else
@@ -182,7 +102,8 @@ jobs:
           PACKAGE_NAME: ${{ steps.read.outputs.package_name }}
           VERSION: ${{ steps.read.outputs.version }}
         run: |
-          if npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+          # Use isolated npmrc to avoid scope contamination from GitHub Packages check
+          if NPM_CONFIG_USERCONFIG=/dev/null npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "npm already has ${PACKAGE_NAME}@${VERSION}."
           else
@@ -191,8 +112,8 @@ jobs:
 
   publish:
     name: Publish to GitHub Packages
-    needs: [test, blackbox-config, package-blackbox, version]
-    if: needs.version.outputs.tag_exists == 'false' && needs.version.outputs.github_version_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    needs: [test, version]
+    if: needs.version.outputs.tag_exists == 'false' && needs.version.outputs.github_version_exists == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -211,27 +132,73 @@ jobs:
           packages_read_token: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
 
   promote-npm:
-    name: Promote to npm registry
+    name: Request npm promotion
     needs: [version, publish]
-    if: needs.publish.result == 'success'
+    if: >-
+      ${{
+        always() &&
+        needs.version.result == 'success' &&
+        needs.version.outputs.tag_exists == 'false' &&
+        needs.version.outputs.npm_version_exists == 'false' &&
+        (
+          needs.publish.result == 'success' ||
+          (
+            needs.version.outputs.github_version_exists == 'true' &&
+            needs.publish.result == 'skipped'
+          )
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
-      id-token: write
-      packages: read
-    uses: d31ma/FOUNDRY/.github/workflows/promote-npm.yml@main
-    with:
-      package_name: ${{ needs.version.outputs.package_name }}
-      version: ${{ needs.version.outputs.version }}
-      npm_dist_tag: latest
-      source_repository: ${{ github.repository }}
-    secrets:
-      PACKAGES_READ_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
+
+    steps:
+      - name: Dispatch FOUNDRY npm promotion
+        env:
+          GH_TOKEN: ${{ secrets.FOUNDRY_DISPATCH_TOKEN }}
+          PACKAGE_NAME: ${{ needs.version.outputs.package_name }}
+          VERSION: ${{ needs.version.outputs.version }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::FOUNDRY_DISPATCH_TOKEN is required to request npm promotion from FOUNDRY."
+            exit 1
+          fi
+
+          jq -n \
+            --arg package_name "$PACKAGE_NAME" \
+            --arg version "$VERSION" \
+            --arg npm_dist_tag "latest" \
+            --arg npm_auth_mode "token" \
+            --arg source_repository "$SOURCE_REPOSITORY" \
+            '{
+              event_type: "promote-npm",
+              client_payload: {
+                package_name: $package_name,
+                version: $version,
+                npm_dist_tag: $npm_dist_tag,
+                npm_auth_mode: $npm_auth_mode,
+                source_repository: $source_repository
+              }
+            }' |
+            gh api repos/d31ma/FOUNDRY/dispatches --input -
 
   github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
     needs: [version, publish, promote-npm]
-    if: needs.version.outputs.tag_exists == 'false'
+    if: >-
+      ${{
+        always() &&
+        needs.version.outputs.tag_exists == 'false' &&
+        needs.promote-npm.result == 'success' &&
+        (
+          needs.publish.result == 'success' ||
+          needs.publish.result == 'skipped'
+        )
+      }}
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+dist-bin/
 
 # Local agent / tooling configs
 .claude/

--- a/README.md
+++ b/README.md
@@ -17,27 +17,83 @@ Each TTID segment contains:
 
 ## Installation
 
-Authenticate with GitHub Packages before installing:
-
-```bash
-npm login --scope=@d31ma --auth-type=legacy --registry=https://npm.pkg.github.com
-```
-
-Then add this to your user or project `.npmrc`:
-
-```ini
-@d31ma:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
-```
-
-See GitHub's npm registry docs for the latest authentication details:
-https://docs.github.com/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages
+Public stable releases install from npm by default:
 
 ```bash
 npm install @d31ma/ttid
 ```
 
+If you are a `d31ma` member and want the private beta channel from GitHub Packages instead, configure a user-level `.npmrc`:
+
+```ini
+# ~/.npmrc
+@d31ma:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}
+always-auth=true
+```
+
+See GitHub's npm registry docs for the latest authentication details:
+https://docs.github.com/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages
+
+After that, the same `npm install @d31ma/ttid` command will resolve from GitHub Packages for your user.
+
 ## Usage
+
+## CLI and Binary Usage
+
+TTID exposes a `ttid` command. Every command writes structured JSON to stdout and exits non-zero on input or lifecycle errors, which makes it practical for Python, Go, Ruby, PHP, Java, shell scripts, and other runtimes to call.
+
+```sh
+ttid generate
+ttid generate 0HDE5K8S8J9
+ttid generate 0HDE5K8S8J9 --delete
+ttid decode 0HDE5K8S8J9
+ttid validate 0HDE5K8S8J9
+```
+
+For language interop, use the machine interface:
+
+```sh
+ttid exec --request '{"requestId":"new-user","op":"generate"}'
+ttid exec --request '{"requestId":"delete-user","op":"generate","id":"0HDE5K8S8J9","delete":true}'
+```
+
+Successful responses look like this:
+
+```json
+{
+  "protocolVersion": 1,
+  "ok": true,
+  "op": "generate",
+  "requestId": "new-user",
+  "durationMs": 1,
+  "result": "0HDE5K8S8J9"
+}
+```
+
+Errors use the same envelope:
+
+```json
+{
+  "protocolVersion": 1,
+  "ok": false,
+  "op": "generate",
+  "requestId": "delete-user",
+  "durationMs": 1,
+  "error": {
+    "name": "Error",
+    "message": "Invalid TTID!"
+  }
+}
+```
+
+Build a standalone executable:
+
+```sh
+bun run build:exe
+./dist-bin/ttid generate
+./dist-bin/ttid exec --request '{"op":"generate"}'
+```
 
 ### Basic ID Generation
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
   "name": "@d31ma/ttid",
-  "version": "26.18.27-2",
+  "version": "26.21.03",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",
+  "bin": {
+    "ttid": "./src/cli/index.js"
+  },
+  "files": [
+    "src/",
+    "types/",
+    "README.md"
+  ],
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit -p jsconfig.json",
+    "build:exe": "mkdir -p ./dist-bin && bun build --compile ./src/cli/index.js --outfile ./dist-bin/ttid",
     "lint": "eslint src test",
     "format": "prettier --write src test"
   },
@@ -23,6 +32,10 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/d31ma/TTID.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "tag": "beta"
   },
   "license": "MIT",
   "keywords": [

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+import {
+    executeMachineOperation,
+    machineErrorResponse,
+    machineSuccessResponse
+} from './machine.js';
+
+const HELP = `ttid - time-tagged identifier generator
+
+Usage:
+  ttid generate [id] [--delete]
+  ttid decode <id>
+  ttid validate <id>
+  ttid uuid <id>
+  ttid exec --request <json|@path|->
+
+Options:
+  --delete       Mark the TTID as deleted when generating from an existing ID
+  --request      Machine request payload, @file path, or - for stdin
+  -h, --help     Show this help and exit
+
+Machine request:
+  {"op":"generate","id":"...","delete":true}
+
+All commands write structured JSON to stdout.`;
+
+/**
+ * @typedef {object} ParsedArgs
+ * @property {string[]} positionals
+ * @property {string | undefined} request
+ * @property {boolean} delete
+ * @property {boolean} help
+ */
+
+class CliArgsParser {
+    /**
+     * @param {string[]} argv
+     */
+    constructor(argv) {
+        this.argv = argv;
+    }
+
+    /**
+     * @returns {ParsedArgs}
+     */
+    parse() {
+        const positionals = [];
+        let request;
+        let del = false;
+        let help = false;
+
+        for (let index = 0; index < this.argv.length; index++) {
+            const arg = this.argv[index];
+            if (arg === '--request') {
+                const value = this.argv[index + 1];
+                if (!value) throw new Error('Missing value for --request');
+                request = value;
+                index++;
+                continue;
+            }
+            if (arg === '--delete') {
+                del = true;
+                continue;
+            }
+            if (arg === '--help' || arg === '-h') {
+                help = true;
+                continue;
+            }
+            positionals.push(arg);
+        }
+
+        return { positionals, request, delete: del, help };
+    }
+}
+
+class JsonSourceLoader {
+    /**
+     * @param {string} source
+     */
+    constructor(source) {
+        this.source = source;
+    }
+
+    /**
+     * @returns {Promise<string>}
+     */
+    async text() {
+        if (this.source === '-') {
+            if (process.stdin.isTTY) throw new Error('JSON input requires <json|@path|->');
+            const chunks = [];
+            for await (const chunk of process.stdin) chunks.push(chunk);
+            return Buffer.concat(chunks).toString('utf8');
+        }
+
+        if (this.source.startsWith('@')) {
+            return await Bun.file(this.source.slice(1)).text();
+        }
+
+        return this.source;
+    }
+
+    /**
+     * @returns {Promise<unknown>}
+     */
+    async json() {
+        const text = await this.text();
+        try {
+            return JSON.parse(text);
+        } catch (cause) {
+            throw new Error(`Invalid JSON input: ${cause instanceof Error ? cause.message : String(cause)}`);
+        }
+    }
+}
+
+class JsonOutput {
+    /**
+     * @param {unknown} value
+     */
+    write(value) {
+        console.log(JSON.stringify(value, null, 2));
+    }
+}
+
+class MachineRequestBuilder {
+    /**
+     * @param {ParsedArgs} args
+     */
+    constructor(args) {
+        this.args = args;
+    }
+
+    /**
+     * @returns {Promise<unknown>}
+     */
+    async build() {
+        const [command, id] = this.args.positionals;
+
+        if (command === 'exec') {
+            if (!this.args.request) throw new Error('Missing --request for exec');
+            return await new JsonSourceLoader(this.args.request).json();
+        }
+
+        if (command === 'generate') {
+            if (this.args.delete && !id) throw new Error('Missing id for --delete');
+            return {
+                op: 'generate',
+                ...(id ? { id } : {}),
+                ...(this.args.delete ? { delete: true } : {})
+            };
+        }
+
+        if (command === 'decode') {
+            if (!id) throw new Error('Missing id for decode');
+            return { op: 'decodeTime', id };
+        }
+
+        if (command === 'validate') {
+            if (!id) throw new Error('Missing id for validate');
+            return { op: 'isTTID', id };
+        }
+
+        if (command === 'uuid') {
+            if (!id) throw new Error('Missing id for uuid');
+            return { op: 'isUUID', id };
+        }
+
+        throw new Error(`Unsupported command "${command ?? ''}"`);
+    }
+}
+
+class TtidCliApp {
+    /**
+     * @param {string[]} argv
+     */
+    constructor(argv) {
+        this.argv = argv;
+        this.request = undefined;
+        this.startedAt = Date.now();
+        this.output = new JsonOutput();
+    }
+
+    async run() {
+        try {
+            const args = new CliArgsParser(this.argv).parse();
+            if (args.help || args.positionals.length === 0) {
+                console.log(HELP);
+                process.exit(args.help ? 0 : 1);
+            }
+
+            this.request = await new MachineRequestBuilder(args).build();
+            const result = executeMachineOperation(this.request);
+            this.output.write(machineSuccessResponse(this.request, this.startedAt, result));
+            process.exit(0);
+        } catch (error) {
+            this.output.write(machineErrorResponse(this.request, this.startedAt, error));
+            process.exit(1);
+        }
+    }
+}
+
+await new TtidCliApp(process.argv.slice(2)).run();

--- a/src/cli/machine.js
+++ b/src/cli/machine.js
@@ -1,0 +1,203 @@
+import TTID from '../index.js';
+
+const MACHINE_PROTOCOL_VERSION = 1;
+
+/**
+ * @typedef {'generate' | 'decodeTime' | 'isTTID' | 'isUUID'} MachineOperation
+ */
+
+/**
+ * @typedef {object} MachineRequest
+ * @property {MachineOperation} op
+ * @property {string=} requestId
+ * @property {string=} id
+ * @property {boolean=} delete
+ */
+
+export class JsonRecord {
+    /**
+     * @param {unknown} value
+     */
+    constructor(value) {
+        this.value = value;
+    }
+
+    /**
+     * @returns {this is { value: Record<string, unknown> }}
+     */
+    isObject() {
+        return typeof this.value === 'object' && this.value !== null && !Array.isArray(this.value);
+    }
+
+    /**
+     * @returns {Record<string, unknown>}
+     */
+    requireObject() {
+        if (!this.isObject()) throw new Error('Machine request body must be a JSON object');
+        return this.value;
+    }
+}
+
+export class MachineRequestEnvelope {
+    /**
+     * @param {unknown} value
+     */
+    constructor(value) {
+        this.value = value;
+    }
+
+    /**
+     * @returns {MachineRequest}
+     */
+    requireRequest() {
+        const request = new JsonRecord(this.value).requireObject();
+        if (typeof request.op !== 'string') {
+            throw new Error('Machine request field "op" must be a string');
+        }
+        return /** @type {MachineRequest} */ (request);
+    }
+
+    /**
+     * @param {keyof MachineRequest} field
+     * @returns {string}
+     */
+    requireString(field) {
+        const request = this.requireRequest();
+        const value = request[field];
+        if (typeof value !== 'string' || value.trim().length === 0) {
+            throw new Error(`Machine request field "${String(field)}" must be a non-empty string`);
+        }
+        return value;
+    }
+}
+
+export class MachineOperationExecutor {
+    /**
+     * @param {unknown} request
+     */
+    constructor(request) {
+        this.envelope = new MachineRequestEnvelope(request);
+    }
+
+    /**
+     * @returns {unknown}
+     */
+    execute() {
+        const request = this.envelope.requireRequest();
+        switch (request.op) {
+            case 'generate':
+                return TTID.generate(request.id, request.delete === true);
+            case 'decodeTime':
+                return TTID.decodeTime(this.envelope.requireString('id'));
+            case 'isTTID': {
+                const value = this.envelope.requireString('id');
+                const createdAt = TTID.isTTID(value);
+                return {
+                    valid: createdAt !== null,
+                    createdAt: createdAt?.getTime() ?? null
+                };
+            }
+            case 'isUUID':
+                return {
+                    valid: TTID.isUUID(this.envelope.requireString('id')) !== null
+                };
+            default:
+                throw new Error(`Unsupported machine operation "${request.op}"`);
+        }
+    }
+}
+
+/**
+ * @param {unknown} request
+ * @returns {unknown}
+ */
+export const executeMachineOperation = (request) => {
+    return new MachineOperationExecutor(request).execute();
+};
+
+export class MachineResponseFactory {
+    /**
+     * @param {unknown} request
+     * @param {number} startedAt
+     */
+    constructor(request, startedAt) {
+        this.request = request;
+        this.startedAt = startedAt;
+    }
+
+    /**
+     * @returns {MachineOperation | null}
+     */
+    get op() {
+        const request = new JsonRecord(this.request);
+        if (request.isObject() && typeof request.value.op === 'string') {
+            return /** @type {MachineOperation} */ (request.value.op);
+        }
+        return null;
+    }
+
+    /**
+     * @returns {string | null}
+     */
+    get requestId() {
+        const request = new JsonRecord(this.request);
+        if (request.isObject() && typeof request.value.requestId === 'string') {
+            return request.value.requestId;
+        }
+        return null;
+    }
+
+    get durationMs() {
+        return Date.now() - this.startedAt;
+    }
+
+    /**
+     * @param {unknown} result
+     */
+    success(result) {
+        return {
+            protocolVersion: MACHINE_PROTOCOL_VERSION,
+            ok: true,
+            op: this.op ?? 'generate',
+            requestId: this.requestId,
+            durationMs: this.durationMs,
+            result
+        };
+    }
+
+    /**
+     * @param {unknown} error
+     */
+    error(error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        return {
+            protocolVersion: MACHINE_PROTOCOL_VERSION,
+            ok: false,
+            op: this.op,
+            requestId: this.requestId,
+            durationMs: this.durationMs,
+            error: {
+                name: err.name,
+                message: err.message
+            }
+        };
+    }
+}
+
+/**
+ * @param {unknown} request
+ * @param {number} startedAt
+ * @param {unknown} result
+ */
+export const machineSuccessResponse = (request, startedAt, result) => {
+    return new MachineResponseFactory(request, startedAt).success(result);
+};
+
+/**
+ * @param {unknown} request
+ * @param {number} startedAt
+ * @param {unknown} error
+ */
+export const machineErrorResponse = (request, startedAt, error) => {
+    return new MachineResponseFactory(request, startedAt).error(error);
+};

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    executeMachineOperation,
+    machineErrorResponse,
+    machineSuccessResponse
+} from '../src/cli/machine.js';
+
+describe('machine interface', () => {
+    test('generates a TTID through the machine interface', () => {
+        const request = {
+            requestId: 'generate-1',
+            op: 'generate'
+        };
+
+        const result = executeMachineOperation(request);
+        const payload = machineSuccessResponse(request, Date.now(), result);
+
+        expect(payload.ok).toBe(true);
+        expect(payload.protocolVersion).toBe(1);
+        expect(payload.op).toBe('generate');
+        expect(payload.requestId).toBe('generate-1');
+        expect(typeof payload.result).toBe('string');
+        expect(String(payload.result)).toHaveLength(11);
+    });
+
+    test('updates and deletes an existing TTID through arguments', () => {
+        const created = executeMachineOperation({ op: 'generate' });
+        const updated = executeMachineOperation({ op: 'generate', id: created });
+        const deleted = executeMachineOperation({ op: 'generate', id: updated, delete: true });
+
+        expect(String(updated).split('-')).toHaveLength(2);
+        expect(String(deleted).split('-')).toHaveLength(3);
+    });
+
+    test('decodes timestamps through the machine interface', () => {
+        const id = String(executeMachineOperation({ op: 'generate' }));
+        const result = executeMachineOperation({
+            requestId: 'decode-1',
+            op: 'decodeTime',
+            id
+        });
+
+        expect(result).toEqual({
+            createdAt: expect.any(Number)
+        });
+    });
+
+    test('validates TTIDs through the machine interface', () => {
+        const id = String(executeMachineOperation({ op: 'generate' }));
+        const result = executeMachineOperation({
+            op: 'isTTID',
+            id
+        });
+
+        expect(result).toEqual({
+            valid: true,
+            createdAt: expect.any(Number)
+        });
+    });
+
+    test('returns structured errors', () => {
+        const request = {
+            requestId: 'bad-generate',
+            op: 'generate',
+            id: 'not-a-valid-ttid'
+        };
+
+        let error;
+        try {
+            executeMachineOperation(request);
+        } catch (caught) {
+            error = caught;
+        }
+
+        const payload = machineErrorResponse(request, Date.now(), error);
+        expect(payload.ok).toBe(false);
+        expect(payload.requestId).toBe('bad-generate');
+        expect(payload.error.message).toBe('Invalid TTID!');
+    });
+
+    test('rejects unsupported operations through the machine interface', () => {
+        expect(() =>
+            executeMachineOperation({
+                op: 'unknownOperation'
+            })
+        ).toThrow('Unsupported machine operation "unknownOperation"');
+    });
+});


### PR DESCRIPTION
## Summary
- Add TTID CLI and machine-readable JSON interface for language-agnostic ID generation
- Add Bun standalone executable build script
- Align CI and publish workflows with CHEX-style release flow
- Bump package version to 26.21.03

## Verification
- bun run typecheck
- bun run lint
- bun test
- bun test ./test/
- bun run build:exe
- ./dist-bin/ttid exec --request '{"requestId":"release-smoke","op":"generate"}'