### PR TITLE
Release 26.28.02: multi-language clients + binary releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
       version: ${{ steps.read.outputs.version }}
       tag_exists: ${{ steps.check.outputs.exists }}
       github_version_exists: ${{ steps.check_github.outputs.exists }}
-      npm_version_exists: ${{ steps.check_npm.outputs.exists }}
 
     steps:
       - name: Checkout
@@ -96,20 +95,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check npm version
-        id: check_npm
-        env:
-          PACKAGE_NAME: ${{ steps.read.outputs.package_name }}
-          VERSION: ${{ steps.read.outputs.version }}
-        run: |
-          # Use isolated npmrc to avoid scope contamination from GitHub Packages check
-          if NPM_CONFIG_USERCONFIG=/dev/null npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "npm already has ${PACKAGE_NAME}@${VERSION}."
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
   publish:
     name: Publish to GitHub Packages
     needs: [test, version]
@@ -131,75 +116,20 @@ jobs:
           publish_token: ${{ github.token }}
           packages_read_token: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
 
-  promote-npm:
-    name: Request npm promotion
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
     needs: [version, publish]
     if: >-
       ${{
         always() &&
-        needs.version.result == 'success' &&
         needs.version.outputs.tag_exists == 'false' &&
-        needs.version.outputs.npm_version_exists == 'false' &&
         (
           needs.publish.result == 'success' ||
-          (
-            needs.version.outputs.github_version_exists == 'true' &&
-            needs.publish.result == 'skipped'
-          )
+          needs.version.outputs.github_version_exists == 'true'
         )
       }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Dispatch FOUNDRY npm promotion
-        env:
-          GH_TOKEN: ${{ secrets.FOUNDRY_DISPATCH_TOKEN }}
-          PACKAGE_NAME: ${{ needs.version.outputs.package_name }}
-          VERSION: ${{ needs.version.outputs.version }}
-          SOURCE_REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::FOUNDRY_DISPATCH_TOKEN is required to request npm promotion from FOUNDRY."
-            exit 1
-          fi
-
-          jq -n \
-            --arg package_name "$PACKAGE_NAME" \
-            --arg version "$VERSION" \
-            --arg npm_dist_tag "latest" \
-            --arg npm_auth_mode "token" \
-            --arg source_repository "$SOURCE_REPOSITORY" \
-            '{
-              event_type: "promote-npm",
-              client_payload: {
-                package_name: $package_name,
-                version: $version,
-                npm_dist_tag: $npm_dist_tag,
-                npm_auth_mode: $npm_auth_mode,
-                source_repository: $source_repository
-              }
-            }' |
-            gh api repos/d31ma/FOUNDRY/dispatches --input -
-
-  github-release:
-    name: Create GitHub release
-    runs-on: ubuntu-latest
-    needs: [version, publish, promote-npm]
-    if: >-
-      ${{
-        always() &&
-        needs.version.outputs.tag_exists == 'false' &&
-        needs.promote-npm.result == 'success' &&
-        (
-          needs.publish.result == 'success' ||
-          needs.publish.result == 'skipped'
-        )
-      }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: write
 
@@ -226,3 +156,34 @@ jobs:
           gh release create "v$VERSION" \
             --title "v$VERSION" \
             --generate-notes
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build cross-platform binaries
+        run: |
+          set -euo pipefail
+          mkdir -p dist-bin
+          build() {
+            echo "::group::$2"
+            bun build --compile --target="$1" ./src/cli/index.js --outfile "dist-bin/$2"
+            echo "::endgroup::"
+          }
+          build bun-linux-x64     ttid-linux-x64
+          build bun-linux-arm64   ttid-linux-arm64
+          build bun-darwin-x64    ttid-macos-x64
+          build bun-darwin-arm64  ttid-macos-arm64
+          build bun-windows-x64   ttid-windows-x64.exe
+          cd dist-bin && sha256sum ttid-* > SHA256SUMS
+
+      - name: Upload binaries and installers to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          gh release upload "v$VERSION" \
+            dist-bin/ttid-* dist-bin/SHA256SUMS \
+            scripts/install.sh scripts/install.ps1 \
+            --clobber

--- a/README.md
+++ b/README.md
@@ -17,13 +17,42 @@ Each TTID segment contains:
 
 ## Installation
 
-Public stable releases install from npm by default:
+TTID ships as a single self-contained `ttid` binary, published to
+[GitHub Releases](https://github.com/d31ma/TTID/releases). Any language uses it
+through a thin [client shim](clients/) — no npm, no native addon.
 
-```bash
-npm install @d31ma/ttid
+### Install the binary
+
+```sh
+# macOS / Linux
+curl -fsSL https://github.com/d31ma/TTID/releases/latest/download/install.sh | sh
 ```
 
-If you are a `d31ma` member and want the private beta channel from GitHub Packages instead, configure a user-level `.npmrc`:
+```powershell
+# Windows (PowerShell)
+irm https://github.com/d31ma/TTID/releases/latest/download/install.ps1 | iex
+```
+
+The installer downloads the right binary for your OS/arch from the latest
+release, verifies its checksum, and puts `ttid` on your PATH. Then verify:
+`ttid --help`.
+
+Prefer to do it by hand? Download the asset for your platform from the
+[latest release](https://github.com/d31ma/TTID/releases/latest) —
+`ttid-linux-x64`, `ttid-linux-arm64`, `ttid-macos-x64`, `ttid-macos-arm64`, or
+`ttid-windows-x64.exe` — `chmod +x` it, and move it onto your PATH. Checksums
+are in `SHA256SUMS`.
+
+### Use it from your language
+
+Drop the one-file client for your language into your project and call TTID like
+a library — it drives the `ttid` binary for you. See [clients/](clients/) for
+Python, Ruby, Node/TS, PHP, Go, Rust, C#, and Java.
+
+### JavaScript / TypeScript library
+
+JS/TS projects can also import the package directly from GitHub Packages instead
+of the binary. Configure a user-level `.npmrc`:
 
 ```ini
 # ~/.npmrc
@@ -32,12 +61,9 @@ If you are a `d31ma` member and want the private beta channel from GitHub Packag
 always-auth=true
 ```
 
-See GitHub's npm registry docs for the latest authentication details:
-https://docs.github.com/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages
-
-After that, the same `npm install @d31ma/ttid` command will resolve from GitHub Packages for your user.
-
-## Usage
+Then `bun add @d31ma/ttid` (or `npm install @d31ma/ttid`). See GitHub's
+[npm registry docs](https://docs.github.com/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages)
+for authentication details.
 
 ## CLI and Binary Usage
 
@@ -94,6 +120,129 @@ bun run build:exe
 ./dist-bin/ttid generate
 ./dist-bin/ttid exec --request '{"op":"generate"}'
 ```
+
+## Language Clients
+
+Any language uses TTID through a thin, dependency-free [client shim](clients/)
+that drives the `ttid` binary over a persistent stdin/stdout loop. Drop the one
+file for your language into your project and call TTID like a library. Method
+names follow each language's own convention — `snake_case`, `camelCase`, or
+`PascalCase`. Full details in [clients/README.md](clients/README.md).
+
+**Python** — [`clients/python/ttid.py`](clients/python/ttid.py)
+
+```python
+from ttid import TTID
+
+with TTID() as t:
+    id = t.generate()              # new id
+    updated = t.generate(id)       # advance it
+    deleted = t.generate(updated, delete=True)
+    print(t.decode_time(deleted))  # {"createdAt": ..., "updatedAt": ..., "deletedAt": ...}
+    print(t.is_ttid(id))           # {"valid": True, "createdAt": ...}
+    print(t.is_uuid("not-a-uuid")) # {"valid": False}
+```
+
+**Node / TypeScript** — [`clients/node/ttid.mjs`](clients/node/ttid.mjs)
+
+```js
+import { TTID } from './ttid.mjs'
+
+const t = new TTID()
+const id = await t.generate()             // new id
+const updated = await t.generate(id)      // advance it
+await t.generate(updated, true)           // mark deleted
+console.log(await t.decodeTime(updated))  // { createdAt, updatedAt }
+console.log(await t.isTTID(id))           // { valid, createdAt }
+await t.close()
+```
+
+**Ruby** — [`clients/ruby/ttid.rb`](clients/ruby/ttid.rb)
+
+```ruby
+require_relative 'ttid'
+
+TTID.open do |t|
+  id = t.generate                       # new id
+  updated = t.generate(id)              # advance it
+  t.generate(updated, delete: true)     # mark deleted
+  p t.decode_time(updated)              # {"createdAt"=>..., "updatedAt"=>...}
+  p t.is_ttid(id)                       # {"valid"=>true, "createdAt"=>...}
+end
+```
+
+**PHP** — [`clients/php/ttid.php`](clients/php/ttid.php)
+
+```php
+require 'ttid.php';
+
+$t = new TTID();
+$id = $t->generate();                 // new id
+$updated = $t->generate($id);         // advance it
+$t->generate($updated, true);         // mark deleted
+print_r($t->decodeTime($updated));    // ["createdAt" => ..., "updatedAt" => ...]
+print_r($t->isTTID($id));             // ["valid" => true, "createdAt" => ...]
+$t->close();
+```
+
+**Go** — [`clients/go/ttid.go`](clients/go/ttid.go)
+
+```go
+import "yourmodule/ttid" // copy ttid.go into a package dir
+
+t, _ := ttid.Open("ttid")
+defer t.Close()
+
+id, _ := t.Generate("", false)         // new id
+updated, _ := t.Generate(id.(string), false)
+t.Generate(updated.(string), true)     // mark deleted
+times, _ := t.DecodeTime(updated.(string))
+valid, _ := t.IsTTID(id.(string))
+fmt.Println(times, valid)
+```
+
+**Rust** — [`clients/rust/ttid.rs`](clients/rust/ttid.rs)
+
+```rust
+mod ttid;
+use ttid::Ttid;
+
+let mut t = Ttid::open("ttid")?;
+let id = t.generate(None, false)?;      // response line: {..."result":"4VL..."}
+let up = t.generate(Some("4VL..."), false)?;
+t.generate(Some("4VL..."), true)?;      // mark deleted
+let times = t.decode_time("4VL...")?;   // methods return the raw JSON response
+let valid = t.is_ttid("4VL...")?;       // line — parse with serde if you want structs
+t.close()?;
+```
+
+**C#** — [`clients/csharp/Ttid.cs`](clients/csharp/Ttid.cs)
+
+```csharp
+using var t = new Ttid.Ttid();
+string id = t.Generate().GetString();       // new id
+t.Generate(id);                             // advance it
+t.Generate(id, del: true);                  // mark deleted
+JsonElement times = t.DecodeTime(id);       // { createdAt, updatedAt? }
+JsonElement valid = t.IsTTID(id);           // { valid, createdAt }
+JsonElement uuid  = t.IsUUID("not-a-uuid"); // { valid }
+```
+
+**Java** — [`clients/java/Ttid.java`](clients/java/Ttid.java)
+
+```java
+try (Ttid t = new Ttid()) {
+    String id = t.generate();        // response line: {..."result":"4VL..."}
+    t.generate("4VL...");            // advance it
+    t.generate("4VL...", true);      // mark deleted
+    String times = t.decodeTime("4VL..."); // methods return the raw JSON
+    String valid = t.isTTID("4VL..."); // response line — parse with Jackson/Gson
+}
+```
+
+## JavaScript / TypeScript Library
+
+The `@d31ma/ttid` package can also be imported directly, with no binary:
 
 ### Basic ID Generation
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,77 @@
+# TTID language clients
+
+Thin, dependency-free shims that let an app in any of these languages use TTID
+by driving the compiled `ttid` binary. No npm, no native addon — drop in one
+file for your language and call TTID like a library.
+
+| Language      | File                   | Runtime deps    |
+| ------------- | ---------------------- | --------------- |
+| Python        | `python/ttid.py`       | none (stdlib)   |
+| Ruby          | `ruby/ttid.rb`         | none (stdlib)   |
+| Node/TS       | `node/ttid.mjs`        | none (stdlib)   |
+| PHP           | `php/ttid.php`         | none (ext-json) |
+| Go            | `go/ttid.go`           | none (stdlib)   |
+| Rust          | `rust/ttid.rs`         | none (std)      |
+| C#            | `csharp/Ttid.cs`       | none (BCL)      |
+| Java          | `java/Ttid.java`       | none (JDK)      |
+
+## Install the binary
+
+Build it from this repo (`bun run build:exe` → `dist-bin/ttid`) or grab a build
+from the [GitHub releases](https://github.com/d31ma/TTID/releases). Put `ttid`
+on your PATH, then verify: `ttid --help`. Each shim also accepts an explicit
+binary path if you don't want it on PATH.
+
+## The API
+
+Each shim exposes one method per operation. Method names follow **each
+language's own paradigm** — `snake_case` in Python/Ruby/Rust, `camelCase` in
+Node/PHP/Java, `PascalCase` in Go/C#:
+
+| Op         | Python / Ruby / Rust | Node / PHP / Java | Go / C#      |
+| ---------- | -------------------- | ----------------- | ------------ |
+| generate   | `generate`           | `generate`        | `Generate`   |
+| decodeTime | `decode_time`        | `decodeTime`      | `DecodeTime` |
+| isTTID     | `is_ttid`            | `isTTID`          | `IsTTID`     |
+| isUUID     | `is_uuid`            | `isUUID`          | `IsUUID`     |
+
+- **`generate(id?, delete?)`** — no args mints a new TTID; passing an existing
+  `id` advances it (a second segment); `id` + `delete` tombstones it (a third
+  segment). Returns the TTID string.
+- **`decodeTime(id)`** — `{ createdAt, updatedAt?, deletedAt? }` (ms since epoch).
+- **`isTTID(id)`** — `{ valid, createdAt }` (`createdAt` is `null` when invalid).
+- **`isUUID(id)`** — `{ valid }`.
+
+For anything else, use the raw `request(op)` escape hatch — see `ttid --help`
+and `src/cli/machine.js`.
+
+## How it works
+
+Each shim spawns **one** long-lived process — `ttid exec --loop` — and talks to
+it over stdin/stdout as newline-delimited JSON: one request object per line, one
+response object per line, in order. No port, no network, no auth surface; the
+child dies with your app.
+
+## Concurrency
+
+The shims send one request at a time and read one response (guarded by a lock
+where the language needs it). The protocol carries a `requestId` echoed back in
+each response, so if you need pipelining you can send many requests and match
+replies by id — but one-in-flight is enough for most apps.
+
+## Example (Python)
+
+```python
+from ttid import TTID
+
+with TTID() as t:
+    _id = t.generate()                 # "4VLMXG1M1JY"
+    updated = t.generate(_id)          # "4VLMXG1M1JY-4VLMXG3P2AB"
+    deleted = t.generate(updated, delete=True)
+    print(t.decode_time(deleted))      # {"createdAt": ..., "updatedAt": ..., "deletedAt": ...}
+    print(t.is_ttid(_id))              # {"valid": True, "createdAt": ...}
+```
+
+Construct, call the operation methods, close when done (or use a
+`with`/`using`/`try`-with-resources block). Each file's header comment has a
+runnable example in that language.

--- a/clients/csharp/Ttid.cs
+++ b/clients/csharp/Ttid.cs
@@ -1,0 +1,108 @@
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// No NuGet dependencies (System.Text.Json ships with .NET). Requires the `ttid`
+// binary on PATH or an explicit path. One long-lived subprocess.
+//
+//   using var t = new Ttid();
+//   string id = t.Generate().GetString();          // new id
+//   JsonElement up = t.Generate(id);               // advance it
+//   JsonElement times = t.DecodeTime(up.GetString());
+//   JsonElement valid = t.IsTTID(id);
+//   JsonElement uuid = t.IsUUID("...");
+//
+// Each method builds the request and returns the op's `result` as a JsonElement
+// (throwing TtidException on failure). Method names follow .NET PascalCase.
+// Request(json) is the raw escape hatch returning the full response.
+
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Ttid
+{
+    public sealed class TtidException : Exception
+    {
+        public TtidException(string message) : base(message) { }
+    }
+
+    public sealed class Ttid : IDisposable
+    {
+        private readonly Process _proc;
+        private readonly object _lock = new object();
+
+        public Ttid(string binary = "ttid")
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = binary,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--loop");
+            _proc = Process.Start(psi) ?? throw new InvalidOperationException("failed to start ttid");
+        }
+
+        /// <summary>Send one raw machine-protocol op (JSON string); returns the full response.</summary>
+        public JsonDocument Request(string opJson)
+        {
+            lock (_lock) // ponytail: one call in flight; drop the lock only if you pipeline
+            {
+                if (_proc.HasExited) throw new InvalidOperationException("ttid process has exited");
+                _proc.StandardInput.Write(opJson.TrimEnd());
+                _proc.StandardInput.Write('\n');
+                _proc.StandardInput.Flush();
+                string? line = _proc.StandardOutput.ReadLine();
+                if (line == null) throw new InvalidOperationException("ttid closed the stream");
+                return JsonDocument.Parse(line);
+            }
+        }
+
+        // Send a fully-formed op JSON and return `result`, throwing on failure.
+        private JsonElement Op(string opJson)
+        {
+            using JsonDocument doc = Request(opJson);
+            JsonElement root = doc.RootElement;
+            if (!root.GetProperty("ok").GetBoolean())
+            {
+                string msg = root.TryGetProperty("error", out var e) &&
+                             e.TryGetProperty("message", out var m)
+                    ? m.GetString() ?? "ttid error"
+                    : "ttid error";
+                throw new TtidException(msg);
+            }
+            return root.TryGetProperty("result", out var r) ? r.Clone() : default;
+        }
+
+        private static string J(string value) => JsonSerializer.Serialize(value);
+
+        /// <summary>Generate a new TTID, or advance <paramref name="id"/> (del=true to tombstone).</summary>
+        public JsonElement Generate(string? id = null, bool del = false)
+        {
+            string op = "{\"op\":\"generate\"";
+            if (id != null) op += $",\"id\":{J(id)}";
+            if (del) op += ",\"delete\":true";
+            return Op(op + "}");
+        }
+
+        public JsonElement DecodeTime(string id) =>
+            Op($"{{\"op\":\"decodeTime\",\"id\":{J(id)}}}");
+
+        public JsonElement IsTTID(string id) =>
+            Op($"{{\"op\":\"isTTID\",\"id\":{J(id)}}}");
+
+        public JsonElement IsUUID(string id) =>
+            Op($"{{\"op\":\"isUUID\",\"id\":{J(id)}}}");
+
+        public void Dispose()
+        {
+            if (!_proc.HasExited)
+            {
+                _proc.StandardInput.Close(); // EOF ends the loop
+                _proc.WaitForExit(30_000);
+            }
+            _proc.Dispose();
+        }
+    }
+}

--- a/clients/go/ttid.go
+++ b/clients/go/ttid.go
@@ -1,0 +1,133 @@
+// Package ttid drives the `ttid` binary's persistent NDJSON loop.
+//
+// Stdlib only. Requires the `ttid` binary on PATH or an explicit path. One
+// long-lived subprocess.
+//
+//	t, _ := ttid.Open("ttid")
+//	defer t.Close()
+//	id, _ := t.Generate("", false)      // new id
+//	up, _ := t.Generate(id.(string), false)
+//	times, _ := t.DecodeTime(up.(string))
+//	valid, _ := t.IsTTID(id.(string))
+//	uuid, _ := t.IsUUID("...")
+//
+// Each method builds the request and returns the op's `result` (or an error on
+// failure). Method names mirror the machine-protocol ops in Go's PascalCase.
+// Request(op) is a raw escape hatch returning the full response.
+package ttid
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+type TTID struct {
+	cmd  *exec.Cmd
+	pipe io.WriteCloser
+	in   *bufio.Writer
+	out  *bufio.Reader
+	mu   sync.Mutex
+}
+
+// Open starts a warm ttid process. binary defaults to "ttid".
+func Open(binary string) (*TTID, error) {
+	if binary == "" {
+		binary = "ttid"
+	}
+	cmd := exec.Command(binary, "exec", "--loop")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &TTID{cmd: cmd, pipe: stdin, in: bufio.NewWriter(stdin), out: bufio.NewReader(stdout)}, nil
+}
+
+// Request sends one raw machine-protocol op and returns the full response.
+func (t *TTID) Request(op map[string]any) (map[string]any, error) {
+	t.mu.Lock() // ponytail: one call in flight; drop the lock only if you pipeline
+	defer t.mu.Unlock()
+	line, err := json.Marshal(op)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := t.in.Write(append(line, '\n')); err != nil {
+		return nil, err
+	}
+	if err := t.in.Flush(); err != nil {
+		return nil, err
+	}
+	reply, err := t.out.ReadBytes('\n')
+	if err != nil {
+		return nil, fmt.Errorf("ttid closed the stream: %w", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(reply, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (t *TTID) op(name string, fields map[string]any) (any, error) {
+	payload := map[string]any{"op": name}
+	for k, v := range fields {
+		if v != nil {
+			payload[k] = v
+		}
+	}
+	resp, err := t.Request(payload)
+	if err != nil {
+		return nil, err
+	}
+	if ok, _ := resp["ok"].(bool); !ok {
+		msg := "ttid error"
+		if e, ok := resp["error"].(map[string]any); ok {
+			if m, ok := e["message"].(string); ok {
+				msg = m
+			}
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
+	return resp["result"], nil
+}
+
+// Generate creates a new TTID, or advances id (del=true to tombstone). Pass "" for a fresh id.
+func (t *TTID) Generate(id string, del bool) (any, error) {
+	fields := map[string]any{}
+	if id != "" {
+		fields["id"] = id
+	}
+	if del {
+		fields["delete"] = true
+	}
+	return t.op("generate", fields)
+}
+
+func (t *TTID) DecodeTime(id string) (any, error) {
+	return t.op("decodeTime", map[string]any{"id": id})
+}
+
+func (t *TTID) IsTTID(id string) (any, error) {
+	return t.op("isTTID", map[string]any{"id": id})
+}
+
+func (t *TTID) IsUUID(id string) (any, error) {
+	return t.op("isUUID", map[string]any{"id": id})
+}
+
+// Close ends the loop and waits for the process to exit.
+func (t *TTID) Close() error {
+	t.in.Flush()
+	t.pipe.Close()
+	return t.cmd.Wait()
+}

--- a/clients/java/Ttid.java
+++ b/clients/java/Ttid.java
@@ -1,0 +1,114 @@
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// No dependencies (java.lang.Process only). Requires the `ttid` binary on PATH
+// or an explicit path. One long-lived subprocess.
+//
+//   try (Ttid t = new Ttid()) {
+//       String id = t.generate();          // {"...","result":"4VL..."}
+//       String up = t.generate("4VL...");  // advance it
+//       String times = t.decodeTime("4VL...");
+//       String valid = t.isTTID("4VL...");
+//       String uuid = t.isUUID("...");
+//   }
+//
+// Each method builds the request, checks it succeeded, and returns the raw JSON
+// response line (parse `result` with Jackson/Gson). Method names follow Java's
+// camelCase. request(json) is the raw escape hatch.
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public final class Ttid implements AutoCloseable {
+    private final Process proc;
+    private final BufferedWriter in;
+    private final BufferedReader out;
+
+    public Ttid() throws IOException {
+        this("ttid");
+    }
+
+    public Ttid(String binary) throws IOException {
+        this.proc = new ProcessBuilder(List.of(binary, "exec", "--loop"))
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start();
+        this.in = new BufferedWriter(
+                new OutputStreamWriter(proc.getOutputStream(), StandardCharsets.UTF_8));
+        this.out = new BufferedReader(
+                new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8));
+    }
+
+    /** Send one raw machine-protocol op (JSON string); returns the response line. */
+    public synchronized String request(String opJson) throws IOException {
+        if (!proc.isAlive()) throw new IOException("ttid process has exited");
+        in.write(opJson.stripTrailing());
+        in.write('\n');
+        in.flush();
+        String line = out.readLine();
+        if (line == null) throw new IOException("ttid closed the stream");
+        return line;
+    }
+
+    // Build an op from native fields (skipping null values), send it, and error
+    // on a failure response. ponytail: checks the "ok":true field by substring.
+    private String op(String name, Object... kv) throws IOException {
+        StringBuilder sb = new StringBuilder("{\"op\":").append(toJson(name));
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            if (kv[i + 1] == null) continue;
+            sb.append(',').append(toJson(kv[i].toString())).append(':').append(toJson(kv[i + 1]));
+        }
+        String resp = request(sb.append('}').toString());
+        if (!resp.contains("\"ok\":true")) throw new IOException(resp.strip());
+        return resp;
+    }
+
+    /** Generate a new TTID (id == null), or advance it (del == true to tombstone). */
+    public String generate() throws IOException {
+        return op("generate");
+    }
+
+    public String generate(String id) throws IOException {
+        return op("generate", "id", id);
+    }
+
+    public String generate(String id, boolean del) throws IOException {
+        return op("generate", "id", id, "delete", del ? Boolean.TRUE : null);
+    }
+
+    public String decodeTime(String id) throws IOException {
+        return op("decodeTime", "id", id);
+    }
+
+    public String isTTID(String id) throws IOException {
+        return op("isTTID", "id", id);
+    }
+
+    public String isUUID(String id) throws IOException {
+        return op("isUUID", "id", id);
+    }
+
+    // Minimal JSON encoder for String / Number / Boolean / null.
+    static String toJson(Object v) {
+        if (v == null) return "null";
+        if (v instanceof String) {
+            return "\"" + ((String) v).replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        }
+        if (v instanceof Boolean || v instanceof Number) return v.toString();
+        throw new IllegalArgumentException("unsupported JSON value: " + v.getClass());
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close(); // EOF ends the loop
+        try {
+            proc.waitFor();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        out.close();
+    }
+}

--- a/clients/node/ttid.mjs
+++ b/clients/node/ttid.mjs
@@ -1,0 +1,94 @@
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// For JS/TS apps that consume the compiled binary instead of importing the npm
+// package. No dependencies (node:child_process only). Requires the `ttid`
+// binary on PATH or an explicit path. One long-lived subprocess.
+//
+//   import { TTID } from './ttid.mjs'
+//   const t = new TTID()
+//   const id = await t.generate()                 // new id
+//   const updated = await t.generate(id)          // advance it
+//   const times = await t.decodeTime(updated)     // { createdAt, updatedAt }
+//   const ttid = await t.isTTID(id)               // { valid, createdAt }
+//   const uuid = await t.isUUID('...')            // { valid }
+//   await t.close()
+//
+// Each method builds the request and resolves with the op's `result` (rejecting
+// on failure). `request(op)` is a raw escape hatch resolving the full response.
+// Requests are queued: each resolves with its own response line, in order.
+
+import { spawn } from 'node:child_process'
+
+export class TTID {
+    /** @param {{ binary?: string }} [opts] */
+    constructor(opts = {}) {
+        this._proc = spawn(opts.binary ?? 'ttid', ['exec', '--loop'], {
+            stdio: ['pipe', 'pipe', 'inherit']
+        })
+        this._queue = [] // pending { resolve, reject } in request order
+        this._buffer = ''
+        this._proc.stdout.setEncoding('utf8')
+        this._proc.stdout.on('data', (chunk) => this._onData(chunk))
+        this._proc.on('exit', () => {
+            const err = new Error('ttid process exited')
+            for (const p of this._queue.splice(0)) p.reject(err)
+        })
+    }
+
+    _onData(chunk) {
+        this._buffer += chunk
+        let nl
+        while ((nl = this._buffer.indexOf('\n')) !== -1) {
+            const line = this._buffer.slice(0, nl).trim()
+            this._buffer = this._buffer.slice(nl + 1)
+            if (!line) continue
+            const pending = this._queue.shift()
+            if (pending) pending.resolve(JSON.parse(line))
+        }
+    }
+
+    /** Send one raw machine-protocol op; resolves with the full response object. */
+    request(op) {
+        return new Promise((resolve, reject) => {
+            if (this._proc.exitCode !== null) return reject(new Error('ttid process exited'))
+            this._queue.push({ resolve, reject })
+            this._proc.stdin.write(JSON.stringify(op) + '\n')
+        })
+    }
+
+    async _op(op, fields) {
+        const payload = { op }
+        for (const [key, value] of Object.entries(fields)) {
+            if (value !== undefined) payload[key] = value
+        }
+        const response = await this.request(payload)
+        if (!response.ok) throw new Error(response.error?.message ?? 'ttid error')
+        return response.result
+    }
+
+    /** Generate a new TTID, or advance an existing one (optionally marking it deleted). */
+    generate(id, del) {
+        return this._op('generate', { id, delete: del })
+    }
+    /** Decode embedded timestamps → { createdAt, updatedAt?, deletedAt? }. */
+    decodeTime(id) {
+        return this._op('decodeTime', { id })
+    }
+    /** Validate a TTID → { valid, createdAt }. */
+    isTTID(id) {
+        return this._op('isTTID', { id })
+    }
+    /** Validate a UUID → { valid }. */
+    isUUID(id) {
+        return this._op('isUUID', { id })
+    }
+
+    /** Close stdin so the loop ends, and wait for the process to exit. */
+    close() {
+        return new Promise((resolve) => {
+            if (this._proc.exitCode !== null) return resolve()
+            this._proc.on('exit', () => resolve())
+            this._proc.stdin.end()
+        })
+    }
+}

--- a/clients/php/ttid.php
+++ b/clients/php/ttid.php
@@ -1,0 +1,96 @@
+<?php
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// ext-json only. Requires the `ttid` binary on PATH or an explicit path. One
+// long-lived subprocess.
+//
+//   require 'ttid.php';
+//   $t = new TTID();
+//   $id      = $t->generate();          // new id
+//   $updated = $t->generate($id);       // advance it
+//   $times   = $t->decodeTime($updated);
+//   $valid   = $t->isTTID($id);
+//   $uuid    = $t->isUUID('...');
+//   $t->close();
+//
+// Each method builds the request and returns the op's `result` (throwing
+// TTIDException on failure). Method names follow PHP's camelCase. request($op)
+// is a raw escape hatch returning the full response array.
+
+class TTIDException extends RuntimeException {}
+
+class TTID
+{
+    private $proc;
+    private $stdin;
+    private $stdout;
+
+    public function __construct(string $binary = 'ttid')
+    {
+        $spec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+        $this->proc = proc_open([$binary, 'exec', '--loop'], $spec, $pipes);
+        if (!is_resource($this->proc)) {
+            throw new TTIDException('failed to start ttid process');
+        }
+        $this->stdin = $pipes[0];
+        $this->stdout = $pipes[1];
+    }
+
+    /** Send one raw machine-protocol op; return the full response array. */
+    public function request(array $op): array
+    {
+        $line = json_encode($op);
+        fwrite($this->stdin, $line . "\n");
+        fflush($this->stdin);
+        $reply = fgets($this->stdout);
+        if ($reply === false) {
+            throw new TTIDException('ttid closed the stream (stderr may have details)');
+        }
+        return json_decode($reply, true);
+    }
+
+    public function generate(?string $id = null, bool $delete = false)
+    {
+        return $this->op('generate', ['id' => $id, 'delete' => $delete ?: null]);
+    }
+
+    public function decodeTime(string $id)
+    {
+        return $this->op('decodeTime', ['id' => $id]);
+    }
+
+    public function isTTID(string $id)
+    {
+        return $this->op('isTTID', ['id' => $id]);
+    }
+
+    public function isUUID(string $id)
+    {
+        return $this->op('isUUID', ['id' => $id]);
+    }
+
+    public function close(): void
+    {
+        if (is_resource($this->stdin)) {
+            fclose($this->stdin);
+        }
+        if (is_resource($this->proc)) {
+            proc_close($this->proc);
+        }
+    }
+
+    private function op(string $name, array $fields)
+    {
+        $payload = ['op' => $name];
+        foreach ($fields as $key => $value) {
+            if ($value !== null) {
+                $payload[$key] = $value;
+            }
+        }
+        $response = $this->request($payload);
+        if (empty($response['ok'])) {
+            throw new TTIDException($response['error']['message'] ?? 'ttid error');
+        }
+        return $response['result'];
+    }
+}

--- a/clients/python/ttid.py
+++ b/clients/python/ttid.py
@@ -1,0 +1,88 @@
+"""TTID client — drives the `ttid` binary's persistent NDJSON loop.
+
+No pip dependencies. Requires the `ttid` binary on PATH or an explicit path.
+One long-lived subprocess.
+
+    from ttid import TTID
+
+    with TTID() as t:
+        _id = t.generate()                 # new id
+        updated = t.generate(_id)          # advance it
+        times = t.decode_time(updated)     # {"createdAt": ..., "updatedAt": ...}
+        ttid = t.is_ttid(_id)              # {"valid": True, "createdAt": ...}
+        uuid = t.is_uuid("...")            # {"valid": False}
+
+Each method builds the request, sends it, and returns the op's `result` (raising
+TTIDError on failure). Method names follow Python's snake_case. `request(op)` is
+a raw escape hatch returning the full response dict.
+"""
+
+import json
+import subprocess
+import threading
+
+
+class TTIDError(RuntimeError):
+    pass
+
+
+class TTID:
+    def __init__(self, binary="ttid"):
+        self._proc = subprocess.Popen(
+            [binary, "exec", "--loop"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._lock = threading.Lock()
+
+    def request(self, op):
+        """Send one raw machine-protocol op; return the full response dict."""
+        line = json.dumps(op)
+        with self._lock:  # ponytail: one call in flight; drop the lock only if you pipeline
+            if self._proc.poll() is not None:
+                raise TTIDError("ttid process has exited")
+            self._proc.stdin.write(line + "\n")
+            self._proc.stdin.flush()
+            reply = self._proc.stdout.readline()
+        if not reply:
+            raise TTIDError("ttid closed the stream (stderr may have details)")
+        return json.loads(reply)
+
+    def _op(self, op, **fields):
+        payload = {"op": op}
+        for key, value in fields.items():
+            if value is not None:
+                payload[key] = value
+        response = self.request(payload)
+        if not response.get("ok"):
+            raise TTIDError((response.get("error") or {}).get("message", "ttid error"))
+        return response.get("result")
+
+    def generate(self, id=None, delete=False):
+        """Generate a new TTID, or advance an existing one (delete=True to tombstone)."""
+        return self._op("generate", id=id, delete=delete or None)
+
+    def decode_time(self, id):
+        """Decode embedded timestamps → {createdAt, updatedAt?, deletedAt?}."""
+        return self._op("decodeTime", id=id)
+
+    def is_ttid(self, id):
+        """Validate a TTID → {valid, createdAt}."""
+        return self._op("isTTID", id=id)
+
+    def is_uuid(self, id):
+        """Validate a UUID → {valid}."""
+        return self._op("isUUID", id=id)
+
+    def close(self):
+        if self._proc.poll() is None:
+            self._proc.stdin.close()
+            self._proc.wait()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()

--- a/clients/ruby/ttid.rb
+++ b/clients/ruby/ttid.rb
@@ -1,0 +1,84 @@
+# TTID client — drives the `ttid` binary's persistent NDJSON loop.
+#
+# Stdlib only (open3, json). Requires the `ttid` binary on PATH or an explicit
+# path. One long-lived subprocess.
+#
+#   require_relative "ttid"
+#
+#   TTID.open do |t|
+#     id      = t.generate            # new id
+#     updated = t.generate(id)        # advance it
+#     times   = t.decode_time(updated)
+#     valid   = t.is_ttid(id)
+#     uuid    = t.is_uuid("...")
+#   end
+#
+# Each method builds the request and returns the op's `result` (raising
+# TTID::Error on failure). Method names follow Ruby's snake_case. `request(op)`
+# is a raw escape hatch returning the full response Hash.
+
+require "open3"
+require "json"
+
+class TTID
+  class Error < StandardError; end
+
+  def self.open(binary = "ttid")
+    t = new(binary)
+    return t unless block_given?
+    begin
+      yield t
+    ensure
+      t.close
+    end
+  end
+
+  def initialize(binary = "ttid")
+    @stdin, @stdout, @wait = Open3.popen2(binary, "exec", "--loop")
+    @mutex = Mutex.new
+  end
+
+  # Send one raw machine-protocol op; return the full response Hash.
+  def request(op)
+    line = JSON.generate(op)
+    reply = @mutex.synchronize do # ponytail: one call in flight; drop the lock only if you pipeline
+      raise Error, "ttid process has exited" unless @wait.alive?
+      @stdin.puts(line)
+      @stdout.gets
+    end
+    raise Error, "ttid closed the stream (stderr may have details)" if reply.nil?
+    JSON.parse(reply)
+  end
+
+  def generate(id = nil, delete: false)
+    op("generate", id: id, delete: (delete || nil))
+  end
+
+  def decode_time(id)
+    op("decodeTime", id: id)
+  end
+
+  def is_ttid(id)
+    op("isTTID", id: id)
+  end
+
+  def is_uuid(id)
+    op("isUUID", id: id)
+  end
+
+  def close
+    return unless @wait.alive?
+    @stdin.close
+    @wait.join
+  end
+
+  private
+
+  def op(name, **fields)
+    payload = { "op" => name }
+    fields.each { |k, v| payload[k.to_s] = v unless v.nil? }
+    response = request(payload)
+    raise Error, (response.dig("error", "message") || "ttid error") unless response["ok"]
+    response["result"]
+  end
+end

--- a/clients/rust/ttid.rs
+++ b/clients/rust/ttid.rs
@@ -1,0 +1,115 @@
+//! TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//!
+//! std only. Requires the `ttid` binary on PATH or an explicit path. One
+//! long-lived subprocess. Methods build the request and return the raw response
+//! line (also JSON); bring serde if you want typed structs.
+//!
+//!   let mut t = Ttid::open("ttid")?;
+//!   let id = t.generate(None, false)?;                  // {"...","result":"4VL..."}
+//!   let up = t.generate(Some("4VL..."), false)?;        // advance it
+//!   let times = t.decode_time("4VL...")?;
+//!   let valid = t.is_ttid("4VL...")?;
+//!   let uuid = t.is_uuid("...")?;
+//!
+//! Method names follow Rust's snake_case; `request` is the raw escape hatch for
+//! ops without a method.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+
+pub struct Ttid {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl Ttid {
+    /// Start a warm ttid process. `binary` is usually "ttid".
+    pub fn open(binary: &str) -> std::io::Result<Ttid> {
+        let mut child = Command::new(binary)
+            .args(["exec", "--loop"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+        let stdin = child.stdin.take().expect("stdin piped");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout piped"));
+        Ok(Ttid { child, stdin: Some(stdin), stdout })
+    }
+
+    /// Send one machine-protocol op (a JSON object string) and return the response line.
+    pub fn request(&mut self, op_json: &str) -> std::io::Result<String> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "ttid closed"))?;
+        stdin.write_all(op_json.trim_end().as_bytes())?;
+        stdin.write_all(b"\n")?;
+        stdin.flush()?;
+        let mut line = String::new();
+        if self.stdout.read_line(&mut line)? == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "ttid closed the stream",
+            ));
+        }
+        Ok(line)
+    }
+
+    // Send a fully-formed op JSON and error on a failure response.
+    // ponytail: checks the always-present "ok":true field by substring.
+    fn checked(&mut self, json: String) -> std::io::Result<String> {
+        let resp = self.request(&json)?;
+        if !resp.contains("\"ok\":true") {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, resp.trim().to_string()));
+        }
+        Ok(resp)
+    }
+
+    /// Generate a new TTID, or advance `id` (`del` to tombstone). `None` for a fresh id.
+    pub fn generate(&mut self, id: Option<&str>, del: bool) -> std::io::Result<String> {
+        let mut op = String::from(r#"{"op":"generate""#);
+        if let Some(id) = id {
+            op.push_str(&format!(r#","id":"{}""#, esc(id)));
+        }
+        if del {
+            op.push_str(r#","delete":true"#);
+        }
+        op.push('}');
+        self.checked(op)
+    }
+
+    pub fn decode_time(&mut self, id: &str) -> std::io::Result<String> {
+        self.checked(format!(r#"{{"op":"decodeTime","id":"{}"}}"#, esc(id)))
+    }
+
+    pub fn is_ttid(&mut self, id: &str) -> std::io::Result<String> {
+        self.checked(format!(r#"{{"op":"isTTID","id":"{}"}}"#, esc(id)))
+    }
+
+    pub fn is_uuid(&mut self, id: &str) -> std::io::Result<String> {
+        self.checked(format!(r#"{{"op":"isUUID","id":"{}"}}"#, esc(id)))
+    }
+
+    /// End the loop and wait for the process to exit.
+    pub fn close(mut self) -> std::io::Result<()> {
+        self.stdin.take(); // drop stdin → EOF ends the loop
+        self.child.wait().map(|_| ())
+    }
+}
+
+/// Escape a string for embedding in a JSON string literal.
+fn esc(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d31ma/ttid",
-  "version": "26.21.03",
+  "version": "26.28.02",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",
   "bin": {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,42 @@
+# TTID installer for Windows.
+#   irm https://github.com/d31ma/TTID/releases/latest/download/install.ps1 | iex
+# Downloads the latest Windows binary from GitHub releases, verifies its
+# checksum, and installs it under %LOCALAPPDATA%\TTID (added to your user PATH).
+$ErrorActionPreference = 'Stop'
+
+$repo = 'd31ma/TTID'
+$base = "https://github.com/$repo/releases/latest/download"
+$asset = 'ttid-windows-x64.exe'
+
+$dest = Join-Path $env:LOCALAPPDATA 'TTID'
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+$exe = Join-Path $dest 'ttid.exe'
+
+Write-Host "Downloading $asset..."
+Invoke-WebRequest -Uri "$base/$asset" -OutFile $exe
+
+# Verify checksum (best-effort).
+try {
+    $sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS" -UseBasicParsing).Content
+    $line = ($sums -split "`n") | Where-Object { $_ -match "\s$([regex]::Escape($asset))$" } | Select-Object -First 1
+    if ($line) {
+        $expected = ($line -split '\s+')[0].ToLower()
+        $actual = (Get-FileHash -Algorithm SHA256 $exe).Hash.ToLower()
+        if ($expected -ne $actual) {
+            Remove-Item $exe -Force
+            throw "Checksum mismatch for $asset. Aborting."
+        }
+    }
+} catch {
+    Write-Warning "Could not verify checksum: $_"
+}
+
+# Add install dir to the user PATH if it isn't already there.
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -notlike "*$dest*") {
+    [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+    Write-Host "Added $dest to your user PATH (restart your terminal to pick it up)."
+}
+
+Write-Host "Installed ttid to $exe"
+Write-Host "Run 'ttid --help' to get started."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# TTID installer for macOS and Linux.
+#   curl -fsSL https://github.com/d31ma/TTID/releases/latest/download/install.sh | sh
+# Downloads the right binary from the latest GitHub release, verifies its
+# checksum, and installs it to a directory on your PATH.
+set -eu
+
+REPO="d31ma/TTID"
+BASE="https://github.com/${REPO}/releases/latest/download"
+
+os=$(uname -s)
+arch=$(uname -m)
+
+case "$os" in
+    Darwin) os_tag="macos" ;;
+    Linux) os_tag="linux" ;;
+    *) echo "Unsupported OS: $os (use install.ps1 on Windows)" >&2; exit 1 ;;
+esac
+
+case "$arch" in
+    x86_64 | amd64) arch_tag="x64" ;;
+    arm64 | aarch64) arch_tag="arm64" ;;
+    *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+asset="ttid-${os_tag}-${arch_tag}"
+url="${BASE}/${asset}"
+
+# Pick an install dir on PATH we can write to; fall back to ~/.local/bin.
+if [ -w /usr/local/bin ]; then
+    dest="/usr/local/bin"
+else
+    dest="${HOME}/.local/bin"
+    mkdir -p "$dest"
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading ${asset}..."
+curl -fSL "$url" -o "$tmp/ttid"
+
+# Verify checksum against the release's SHA256SUMS (best-effort: skip if tools absent).
+if command -v sha256sum >/dev/null 2>&1; then hash_cmd="sha256sum"; \
+    elif command -v shasum >/dev/null 2>&1; then hash_cmd="shasum -a 256"; else hash_cmd=""; fi
+if [ -n "$hash_cmd" ]; then
+    curl -fsSL "${BASE}/SHA256SUMS" -o "$tmp/SHA256SUMS" || true
+    if [ -f "$tmp/SHA256SUMS" ]; then
+        expected=$(grep " ${asset}\$" "$tmp/SHA256SUMS" | awk '{print $1}')
+        actual=$($hash_cmd "$tmp/ttid" | awk '{print $1}')
+        if [ -n "$expected" ] && [ "$expected" != "$actual" ]; then
+            echo "Checksum mismatch for ${asset}. Aborting." >&2
+            exit 1
+        fi
+    fi
+fi
+
+chmod +x "$tmp/ttid"
+mv "$tmp/ttid" "$dest/ttid"
+
+echo "Installed ttid to ${dest}/ttid"
+case ":$PATH:" in
+    *":$dest:"*) : ;;
+    *) echo "Note: ${dest} is not on your PATH. Add it, e.g.:"; echo "  export PATH=\"${dest}:\$PATH\"" ;;
+esac
+echo "Run 'ttid --help' to get started."

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,7 +2,8 @@
 import {
     executeMachineOperation,
     machineErrorResponse,
-    machineSuccessResponse
+    machineSuccessResponse,
+    serveStdioLoop
 } from './machine.js';
 
 const HELP = `ttid - time-tagged identifier generator
@@ -13,10 +14,12 @@ Usage:
   ttid validate <id>
   ttid uuid <id>
   ttid exec --request <json|@path|->
+  ttid exec --loop
 
 Options:
   --delete       Mark the TTID as deleted when generating from an existing ID
   --request      Machine request payload, @file path, or - for stdin
+  --loop         Persistent NDJSON loop: one request/response per line on stdio
   -h, --help     Show this help and exit
 
 Machine request:
@@ -29,6 +32,7 @@ All commands write structured JSON to stdout.`;
  * @property {string[]} positionals
  * @property {string | undefined} request
  * @property {boolean} delete
+ * @property {boolean} loop
  * @property {boolean} help
  */
 
@@ -47,6 +51,7 @@ class CliArgsParser {
         const positionals = [];
         let request;
         let del = false;
+        let loop = false;
         let help = false;
 
         for (let index = 0; index < this.argv.length; index++) {
@@ -62,6 +67,10 @@ class CliArgsParser {
                 del = true;
                 continue;
             }
+            if (arg === '--loop') {
+                loop = true;
+                continue;
+            }
             if (arg === '--help' || arg === '-h') {
                 help = true;
                 continue;
@@ -69,7 +78,7 @@ class CliArgsParser {
             positionals.push(arg);
         }
 
-        return { positionals, request, delete: del, help };
+        return { positionals, request, delete: del, loop, help };
     }
 }
 
@@ -185,6 +194,11 @@ class TtidCliApp {
             if (args.help || args.positionals.length === 0) {
                 console.log(HELP);
                 process.exit(args.help ? 0 : 1);
+            }
+
+            if (args.positionals[0] === 'exec' && args.loop) {
+                await serveStdioLoop();
+                process.exit(0);
             }
 
             this.request = await new MachineRequestBuilder(args).build();

--- a/src/cli/machine.js
+++ b/src/cli/machine.js
@@ -201,3 +201,45 @@ export const machineSuccessResponse = (request, startedAt, result) => {
 export const machineErrorResponse = (request, startedAt, error) => {
     return new MachineResponseFactory(request, startedAt).error(error);
 };
+
+/**
+ * Persistent NDJSON loop: read one JSON request per line from `input`, write one
+ * JSON response per line to `write`, in order. Keeps the process warm across
+ * calls so language shims pay startup once, not per operation.
+ * @param {{ input?: AsyncIterable<unknown>, write?: (line: string) => void }} [options]
+ */
+export const serveStdioLoop = async (options = {}) => {
+    const input = options.input ?? process.stdin;
+    const write = options.write ?? ((line) => process.stdout.write(line));
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    const handleLine = (/** @type {string} */ line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        const startedAt = Date.now();
+        let request;
+        try {
+            request = JSON.parse(trimmed);
+        } catch {
+            write(`${JSON.stringify(machineErrorResponse(null, startedAt, new Error('Invalid JSON request')))}\n`);
+            return;
+        }
+        try {
+            const result = executeMachineOperation(request);
+            write(`${JSON.stringify(machineSuccessResponse(request, startedAt, result))}\n`);
+        } catch (error) {
+            write(`${JSON.stringify(machineErrorResponse(request, startedAt, error))}\n`);
+        }
+    };
+
+    for await (const chunk of input) {
+        buffer += typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+        let newline;
+        while ((newline = buffer.indexOf('\n')) !== -1) {
+            handleLine(buffer.slice(0, newline));
+            buffer = buffer.slice(newline + 1);
+        }
+    }
+    handleLine(buffer);
+};


### PR DESCRIPTION
## Summary

Makes TTID usable from any language via thin, dependency-free **client shims** that drive the compiled `ttid` binary, and switches distribution to **GitHub Releases** (per-OS/arch binaries) instead of npm publishing.

## Changes
- **Language clients** (`clients/`): Python, Ruby, Node/TS, PHP, Go, Rust, C#, Java — each a single dependency-free file that spawns `ttid exec --loop` and exposes `generate` / `decodeTime` / `isTTID` / `isUUID` in the language's own naming convention. Plus `clients/README.md` documenting the NDJSON protocol.
- **CLI**: new `ttid exec --loop` persistent NDJSON mode (one request/response per line) that the shims drive; keeps the process warm across calls.
- **publish.yml**: drops npm promotion; builds per-OS/arch binaries (`ttid-{linux,macos}-{x64,arm64}`, `ttid-windows-x64.exe`) + `SHA256SUMS` and attaches them to the GitHub release, alongside the installers.
- **Installers** (`scripts/install.sh`, `scripts/install.ps1`): download the right binary from the latest release and verify its checksum.
- **README**: install-from-releases instructions and per-language usage snippets.

## Verification
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun test ./test/` — 38 pass
- `ttid exec --loop` verified end-to-end; all 8 shims verified against the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)