### PR TITLE
chore: stop publishing the package to all registries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: release-${{ github.repository }}
@@ -42,10 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      package_name: ${{ steps.read.outputs.package_name }}
       version: ${{ steps.read.outputs.version }}
       tag_exists: ${{ steps.check.outputs.exists }}
-      github_version_exists: ${{ steps.check_github.outputs.exists }}
 
     steps:
       - name: Checkout
@@ -56,11 +53,8 @@ jobs:
       - name: Read package version
         id: read
         run: |
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
-          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Package: $PACKAGE_NAME"
           echo "Version: $VERSION"
 
       - name: Check version tag
@@ -70,65 +64,16 @@ jobs:
         run: |
           if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG already exists; skipping publish and release."
+            echo "Tag $TAG already exists; skipping release."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Check GitHub Packages version
-        id: check_github
-        env:
-          PACKAGE_NAME: ${{ steps.read.outputs.package_name }}
-          VERSION: ${{ steps.read.outputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          {
-            echo "@d31ma:registry=https://npm.pkg.github.com"
-            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
-            echo "always-auth=true"
-          } > "$RUNNER_TEMP/gh-packages.npmrc"
-
-          if NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/gh-packages.npmrc" npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "GitHub Packages already has ${PACKAGE_NAME}@${VERSION}."
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  publish:
-    name: Publish to GitHub Packages
-    needs: [test, version]
-    if: needs.version.outputs.tag_exists == 'false' && needs.version.outputs.github_version_exists == 'false'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      packages: write
-    environment: packages-prod
-
-    steps:
-      - name: Publish via FOUNDRY
-        uses: d31ma/FOUNDRY/.github/actions/publish-github-package@main
-        with:
-          package_name: ${{ needs.version.outputs.package_name }}
-          version: ${{ needs.version.outputs.version }}
-          github_dist_tag: beta
-          publish_token: ${{ github.token }}
-          packages_read_token: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
 
   github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
-    needs: [version, publish]
-    if: >-
-      ${{
-        always() &&
-        needs.version.outputs.tag_exists == 'false' &&
-        (
-          needs.publish.result == 'success' ||
-          needs.version.outputs.github_version_exists == 'true'
-        )
-      }}
+    needs: [test, version]
+    if: needs.version.outputs.tag_exists == 'false'
     timeout-minutes: 15
     permissions:
       contents: write

--- a/package.json
+++ b/package.json
@@ -33,10 +33,6 @@
     "type": "git",
     "url": "git+https://github.com/d31ma/TTID.git"
   },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
-    "tag": "beta"
-  },
   "license": "MIT",
   "keywords": [
     "typescript",


### PR DESCRIPTION
TTID is now distributed as a binary via GitHub Releases plus per-language client shims — not as an installable package. This removes package publishing entirely (public npm was already gone; this drops GitHub Packages too).

- **publish.yml**: removes the "Publish to GitHub Packages" job (FOUNDRY) and its version-check/permission plumbing. The workflow now only builds the cross-platform binaries and creates the GitHub release + tag.
- **package.json**: removes `publishConfig` (the GitHub Packages registry pointer).

Follows the README npm cleanup in #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)