### PR TITLE
feat(clients): add Swift, Kotlin, and Dart clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/d31ma/TTID/releases/latest"><img src="https://img.shields.io/github/v/release/d31ma/TTID?label=release&color=2ea043" alt="Latest release"></a>
   <a href="https://github.com/d31ma/TTID/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/d31ma/TTID/ci.yml?branch=main&label=build" alt="Build status"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license"></a>
-  <img src="https://img.shields.io/badge/clients-8%20languages-8957e5" alt="8 language clients">
+  <img src="https://img.shields.io/badge/clients-12-8957e5" alt="12 language clients">
   <a href="https://github.com/d31ma/TTID/stargazers"><img src="https://img.shields.io/github/stars/d31ma/TTID?style=flat&color=e3b341" alt="GitHub stars"></a>
 </p>
 
@@ -57,7 +57,7 @@ Base-36, 11-character segments. Lexicographically sortable by creation time and 
 
 ### 🌍 Any language
 
-Dependency-free client shims for **8 languages** drive a single `ttid` binary.
+Dependency-free client shims for **11 languages** drive a single `ttid` binary.
 
 </td>
 <td width="33%" valign="top">
@@ -155,7 +155,8 @@ are in `SHA256SUMS`.
 
 Drop the one-file client for your language into your project and call TTID like
 a library — it drives the `ttid` binary for you. See [clients/](clients/) for
-Python, Ruby, Node/TS, PHP, Go, Rust, C#, and Java.
+Python, Ruby, Node/TS, PHP, Go, Rust, C#, Java, Swift, Kotlin, Dart, and the
+browser.
 
 ---
 
@@ -235,6 +236,9 @@ names follow each language's own convention — `snake_case`, `camelCase`, or
 | Rust | [`clients/rust/ttid.rs`](clients/rust/ttid.rs) | `snake_case` |
 | C# | [`clients/csharp/Ttid.cs`](clients/csharp/Ttid.cs) | `PascalCase` |
 | Java | [`clients/java/Ttid.java`](clients/java/Ttid.java) | `camelCase` |
+| Swift | [`clients/swift/Ttid.swift`](clients/swift/Ttid.swift) | `camelCase` |
+| Kotlin | [`clients/kotlin/Ttid.kt`](clients/kotlin/Ttid.kt) | `camelCase` |
+| Dart | [`clients/dart/ttid.dart`](clients/dart/ttid.dart) | `camelCase` |
 | Web (browser) | [`clients/web/ttid.mjs`](clients/web/ttid.mjs) | native — no binary |
 
 > The **web client** is native pure-JS — a browser can't spawn the binary, so it reimplements TTID directly and mirrors the library's static API.
@@ -370,6 +374,53 @@ try (Ttid t = new Ttid()) {
     String times = t.decodeTime("4VL..."); // methods return the raw JSON
     String valid = t.isTTID("4VL..."); // response line — parse with Jackson/Gson
 }
+```
+
+</details>
+
+<details>
+<summary><strong>Swift</strong></summary>
+
+```swift
+let t = try Ttid()
+let id = try t.generate() as! String    // new id
+_ = try t.generate(id)                   // advance it
+_ = try t.generate(id, delete: true)     // mark deleted
+let times = try t.decodeTime(id)         // ["createdAt": ..., "updatedAt": ...]
+let valid = try t.isTTID(id)             // ["valid": true, "createdAt": ...]
+let uuid = try t.isUUID("not-a-uuid")    // ["valid": false]
+t.close()
+```
+
+</details>
+
+<details>
+<summary><strong>Kotlin</strong></summary>
+
+```kotlin
+Ttid().use { t ->
+    val id = t.generate()        // response line: {..."result":"4VL..."}
+    t.generate("4VL...")         // advance it
+    t.generate("4VL...", true)   // mark deleted
+    val times = t.decodeTime("4VL...") // methods return the raw JSON
+    val valid = t.isTTID("4VL...")     // response line — parse with kotlinx/Gson
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Dart</strong></summary>
+
+```dart
+final t = await Ttid.open();
+final id = await t.generate() as String;   // new id
+await t.generate(id);                       // advance it
+await t.generate(id, true);                 // mark deleted
+print(await t.decodeTime(id));              // {createdAt: ..., updatedAt: ...}
+print(await t.isTtid(id));                  // {valid: true, createdAt: ...}
+print(await t.isUuid('not-a-uuid'));        // {valid: false}
+await t.close();
 ```
 
 </details>

--- a/clients/README.md
+++ b/clients/README.md
@@ -14,6 +14,9 @@ file for your language and call TTID like a library.
 | Rust          | `rust/ttid.rs`         | none (std)      |
 | C#            | `csharp/Ttid.cs`       | none (BCL)      |
 | Java          | `java/Ttid.java`       | none (JDK)      |
+| Swift         | `swift/Ttid.swift`     | none (Foundation) |
+| Kotlin        | `kotlin/Ttid.kt`       | none (JDK)      |
+| Dart          | `dart/ttid.dart`       | none (stdlib)   |
 | Web (browser) | `web/ttid.mjs`         | none — no binary |
 
 > **The web client is different.** A browser can't spawn a subprocess, so
@@ -35,14 +38,17 @@ binary path if you don't want it on PATH.
 
 Each shim exposes one method per operation. Method names follow **each
 language's own paradigm** — `snake_case` in Python/Ruby/Rust, `camelCase` in
-Node/PHP/Java, `PascalCase` in Go/C#:
+Node/PHP/Java/Swift/Kotlin, `PascalCase` in Go/C#:
 
-| Op         | Python / Ruby / Rust | Node / PHP / Java | Go / C#      |
-| ---------- | -------------------- | ----------------- | ------------ |
-| generate   | `generate`           | `generate`        | `Generate`   |
-| decodeTime | `decode_time`        | `decodeTime`      | `DecodeTime` |
-| isTTID     | `is_ttid`            | `isTTID`          | `IsTTID`     |
-| isUUID     | `is_uuid`            | `isUUID`          | `IsUUID`     |
+| Op         | Python / Ruby / Rust | Node / PHP / Java / Swift / Kotlin | Go / C#      |
+| ---------- | -------------------- | ---------------------------------- | ------------ |
+| generate   | `generate`           | `generate`                         | `Generate`   |
+| decodeTime | `decode_time`        | `decodeTime`                       | `DecodeTime` |
+| isTTID     | `is_ttid`            | `isTTID`                           | `IsTTID`     |
+| isUUID     | `is_uuid`            | `isUUID`                           | `IsUUID`     |
+
+Dart follows the same camelCase but writes acronyms as words — `decodeTime`,
+`isTtid`, `isUuid` — per Dart's style guide.
 
 - **`generate(id?, delete?)`** — no args mints a new TTID; passing an existing
   `id` advances it (a second segment); `id` + `delete` tombstones it (a third

--- a/clients/dart/ttid.dart
+++ b/clients/dart/ttid.dart
@@ -1,0 +1,81 @@
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// Stdlib only (dart:io, dart:convert). Requires the `ttid` binary on PATH or an
+// explicit path. One long-lived subprocess.
+//
+//   final t = await Ttid.open();
+//   final id = await t.generate();               // new id
+//   final up = await t.generate(id as String);   // advance it
+//   await t.generate(up as String, true);        // mark deleted
+//   print(await t.decodeTime(up));               // {createdAt: ..., updatedAt: ...}
+//   print(await t.isTtid(id));                   // {valid: true, createdAt: ...}
+//   print(await t.isUuid('not-a-uuid'));         // {valid: false}
+//   await t.close();
+//
+// Each method builds the request and returns the op's `result` (throwing on
+// failure). Method names follow Dart's lowerCamelCase (acronyms as words).
+// request(op) is the raw escape hatch returning the full response map.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+class TtidException implements Exception {
+  final String message;
+  TtidException(this.message);
+  @override
+  String toString() => 'TtidException: $message';
+}
+
+class Ttid {
+  final Process _proc;
+  final StreamIterator<String> _lines;
+
+  Ttid._(this._proc, this._lines);
+
+  /// Start a warm ttid process. [binary] defaults to "ttid".
+  static Future<Ttid> open([String binary = 'ttid']) async {
+    final proc = await Process.start(binary, ['exec', '--loop']);
+    final lines = StreamIterator(
+        proc.stdout.transform(utf8.decoder).transform(const LineSplitter()));
+    return Ttid._(proc, lines);
+  }
+
+  /// Send one raw machine-protocol op; return the full response map.
+  Future<Map<String, dynamic>> request(Map<String, dynamic> op) async {
+    _proc.stdin.writeln(jsonEncode(op));
+    await _proc.stdin.flush();
+    // ponytail: one call in flight; await each call before the next, or guard
+    // with a lock if you pipeline.
+    if (!await _lines.moveNext()) throw TtidException('ttid closed the stream');
+    return jsonDecode(_lines.current) as Map<String, dynamic>;
+  }
+
+  Future<dynamic> _op(String op, Map<String, dynamic> fields) async {
+    final payload = <String, dynamic>{'op': op};
+    fields.forEach((key, value) {
+      if (value != null) payload[key] = value;
+    });
+    final response = await request(payload);
+    if (response['ok'] != true) {
+      final error = response['error'];
+      throw TtidException(
+          (error is Map && error['message'] is String) ? error['message'] : 'ttid error');
+    }
+    return response['result'];
+  }
+
+  /// Generate a new TTID, or advance [id] ([delete] to tombstone). Pass null for a fresh id.
+  Future<dynamic> generate([String? id, bool delete = false]) =>
+      _op('generate', {'id': id, 'delete': delete ? true : null});
+
+  Future<dynamic> decodeTime(String id) => _op('decodeTime', {'id': id});
+  Future<dynamic> isTtid(String id) => _op('isTTID', {'id': id});
+  Future<dynamic> isUuid(String id) => _op('isUUID', {'id': id});
+
+  /// Close stdin so the loop ends, and wait for the process to exit.
+  Future<void> close() async {
+    await _proc.stdin.close();
+    await _proc.exitCode;
+  }
+}

--- a/clients/kotlin/Ttid.kt
+++ b/clients/kotlin/Ttid.kt
@@ -1,0 +1,76 @@
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// No dependencies (java.lang.ProcessBuilder only). Requires the `ttid` binary on
+// PATH or an explicit path. One long-lived subprocess.
+//
+//   Ttid().use { t ->
+//       val id = t.generate()        // {..."result":"4VL..."}
+//       t.generate("4VL...")         // advance it
+//       t.generate("4VL...", true)   // mark deleted
+//       val times = t.decodeTime("4VL...") // methods return the raw JSON
+//       val valid = t.isTTID("4VL...")     // response line — parse with kotlinx/Gson
+//   }
+//
+// Each method builds the request, checks it succeeded, and returns the raw JSON
+// response line. Method names follow Kotlin's camelCase. request(json) is the
+// raw escape hatch.
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+class Ttid(binary: String = "ttid") : AutoCloseable {
+    private val proc = ProcessBuilder(binary, "exec", "--loop")
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+    private val input = BufferedWriter(OutputStreamWriter(proc.outputStream, Charsets.UTF_8))
+    private val output = BufferedReader(InputStreamReader(proc.inputStream, Charsets.UTF_8))
+
+    /** Send one raw machine-protocol op (JSON string); returns the response line. */
+    @Synchronized
+    fun request(opJson: String): String {
+        if (!proc.isAlive) throw RuntimeException("ttid process has exited")
+        input.write(opJson.trimEnd())
+        input.write("\n")
+        input.flush()
+        return output.readLine() ?: throw RuntimeException("ttid closed the stream")
+    }
+
+    // Build an op from native fields (skipping null values), send it, and error
+    // on a failure response. ponytail: checks the "ok":true field by substring.
+    private fun op(name: String, vararg kv: Pair<String, Any?>): String {
+        val sb = StringBuilder("{\"op\":").append(toJson(name))
+        for ((key, value) in kv) {
+            if (value == null) continue
+            sb.append(',').append(toJson(key)).append(':').append(toJson(value))
+        }
+        val resp = request(sb.append('}').toString())
+        if (!resp.contains("\"ok\":true")) throw RuntimeException(resp.trim())
+        return resp
+    }
+
+    /** Generate a new TTID (id == null), or advance it (delete == true to tombstone). */
+    fun generate(id: String? = null, delete: Boolean = false): String =
+        op("generate", "id" to id, "delete" to if (delete) true else null)
+
+    fun decodeTime(id: String): String = op("decodeTime", "id" to id)
+    fun isTTID(id: String): String = op("isTTID", "id" to id)
+    fun isUUID(id: String): String = op("isUUID", "id" to id)
+
+    override fun close() {
+        input.close() // EOF ends the loop
+        proc.waitFor()
+        output.close()
+    }
+
+    companion object {
+        // Minimal JSON encoder for String / Number / Boolean / null.
+        fun toJson(v: Any?): String = when (v) {
+            null -> "null"
+            is String -> "\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+            is Boolean, is Number -> v.toString()
+            else -> throw IllegalArgumentException("unsupported JSON value: $v")
+        }
+    }
+}

--- a/clients/swift/Ttid.swift
+++ b/clients/swift/Ttid.swift
@@ -1,0 +1,95 @@
+// TTID client — drives the `ttid` binary's persistent NDJSON loop.
+//
+// Foundation only. Requires the `ttid` binary on PATH or an explicit path. One
+// long-lived subprocess.
+//
+//   let t = try Ttid()
+//   let id = try t.generate() as! String        // new id
+//   _ = try t.generate(id)                       // advance it
+//   _ = try t.generate(id, delete: true)         // mark deleted
+//   let times = try t.decodeTime(id)             // ["createdAt": ..., "updatedAt": ...]
+//   let valid = try t.isTTID(id)                 // ["valid": true, "createdAt": ...]
+//   let uuid = try t.isUUID("not-a-uuid")        // ["valid": false]
+//   t.close()
+//
+// Each method builds the request and returns the op's `result` (throwing on
+// failure). Method names follow Swift's camelCase. request(_:) is the raw escape
+// hatch returning the full response dictionary.
+
+import Foundation
+
+enum TtidError: Error { case failure(String) }
+
+final class Ttid {
+    private let process = Process()
+    private let stdinPipe = Pipe()
+    private let stdoutPipe = Pipe()
+    private let handle: FileHandle
+    private let lock = NSLock()
+    private var buffer = Data()
+
+    init(binary: String = "ttid") throws {
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [binary, "exec", "--loop"]
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        handle = stdoutPipe.fileHandleForReading
+        try process.run()
+    }
+
+    /// Send one raw machine-protocol op; return the full response dictionary.
+    @discardableResult
+    func request(_ op: [String: Any]) throws -> [String: Any] {
+        lock.lock() // ponytail: one call in flight; drop the lock only if you pipeline
+        defer { lock.unlock() }
+        let data = try JSONSerialization.data(withJSONObject: op)
+        let writer = stdinPipe.fileHandleForWriting
+        writer.write(data)
+        writer.write(Data([0x0a]))
+        let line = try readLine()
+        guard let obj = try JSONSerialization.jsonObject(with: line) as? [String: Any] else {
+            throw TtidError.failure("ttid returned a non-object response")
+        }
+        return obj
+    }
+
+    private func readLine() throws -> Data {
+        while true {
+            if let newline = buffer.firstIndex(of: 0x0a) {
+                let line = buffer.subdata(in: buffer.startIndex..<newline)
+                buffer = buffer.subdata(in: (newline + 1)..<buffer.endIndex)
+                return line
+            }
+            let chunk = handle.availableData
+            if chunk.isEmpty { throw TtidError.failure("ttid closed the stream") }
+            buffer.append(chunk)
+        }
+    }
+
+    private func op(_ name: String, _ fields: [String: Any?]) throws -> Any? {
+        var payload: [String: Any] = ["op": name]
+        for (key, value) in fields { if let value = value { payload[key] = value } }
+        let response = try request(payload)
+        if response["ok"] as? Bool != true {
+            let message = (response["error"] as? [String: Any])?["message"] as? String ?? "ttid error"
+            throw TtidError.failure(message)
+        }
+        return response["result"]
+    }
+
+    /// Generate a new TTID, or advance `id` (`delete` to tombstone). Pass nil for a fresh id.
+    @discardableResult
+    func generate(_ id: String? = nil, delete: Bool = false) throws -> Any? {
+        try op("generate", ["id": id, "delete": delete ? true : nil])
+    }
+
+    func decodeTime(_ id: String) throws -> Any? { try op("decodeTime", ["id": id]) }
+    func isTTID(_ id: String) throws -> Any? { try op("isTTID", ["id": id]) }
+    func isUUID(_ id: String) throws -> Any? { try op("isUUID", ["id": id]) }
+
+    /// Close stdin so the loop ends, and wait for the process to exit.
+    func close() {
+        stdinPipe.fileHandleForWriting.closeFile()
+        process.waitUntilExit()
+    }
+}


### PR DESCRIPTION
Adds three more binary-driven client shims, following the same `ttid exec --loop` NDJSON pattern as the existing ones.

- **`clients/swift/Ttid.swift`** — Foundation only; parses responses and returns the op result (throws on failure). camelCase API.
- **`clients/kotlin/Ttid.kt`** — JDK only; builds JSON and returns the raw response line (parse with kotlinx/Gson), mirroring the Java shim. camelCase API.
- **`clients/dart/ttid.dart`** — `dart:io`/`dart:convert`; async, returns the parsed result (throws on failure). camelCase with acronyms-as-words (`isTtid`/`isUuid`) per Dart style.

Docs updated (`clients/README.md`, `README.md`); clients badge bumped to 12.

**Verified end-to-end** against the binary for all three (create → advance → delete, decode, `isTTID`/`isUUID`, immutability enforcement).

Client lineup is now **12**: Python, Ruby, Node/TS, PHP, Go, Rust, C#, Java, Swift, Kotlin, Dart, and Web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)