### PR TITLE
feat(clients): add native pure-Dart client for Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/d31ma/TTID/releases/latest"><img src="https://img.shields.io/github/v/release/d31ma/TTID?label=release&color=2ea043" alt="Latest release"></a>
   <a href="https://github.com/d31ma/TTID/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/d31ma/TTID/ci.yml?branch=main&label=build" alt="Build status"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license"></a>
-  <img src="https://img.shields.io/badge/clients-12-8957e5" alt="12 language clients">
+  <img src="https://img.shields.io/badge/clients-13-8957e5" alt="13 clients">
   <a href="https://github.com/d31ma/TTID/stargazers"><img src="https://img.shields.io/github/stars/d31ma/TTID?style=flat&color=e3b341" alt="GitHub stars"></a>
 </p>
 
@@ -239,9 +239,10 @@ names follow each language's own convention — `snake_case`, `camelCase`, or
 | Swift | [`clients/swift/Ttid.swift`](clients/swift/Ttid.swift) | `camelCase` |
 | Kotlin | [`clients/kotlin/Ttid.kt`](clients/kotlin/Ttid.kt) | `camelCase` |
 | Dart | [`clients/dart/ttid.dart`](clients/dart/ttid.dart) | `camelCase` |
+| Dart (Flutter) | [`clients/dart/ttid_native.dart`](clients/dart/ttid_native.dart) | native — no binary |
 | Web (browser) | [`clients/web/ttid.mjs`](clients/web/ttid.mjs) | native — no binary |
 
-> The **web client** is native pure-JS — a browser can't spawn the binary, so it reimplements TTID directly and mirrors the library's static API.
+> The **web** and **Flutter** clients are native (pure JS / pure Dart) — a browser and Flutter on mobile/web can't spawn the binary, so they reimplement TTID directly and mirror the library's static API. Their IDs still interoperate with every other client. Use `clients/dart/ttid.dart` on a server/desktop that has the binary.
 
 <details open>
 <summary><strong>Python</strong></summary>
@@ -421,6 +422,22 @@ print(await t.decodeTime(id));              // {createdAt: ..., updatedAt: ...}
 print(await t.isTtid(id));                  // {valid: true, createdAt: ...}
 print(await t.isUuid('not-a-uuid'));        // {valid: false}
 await t.close();
+```
+
+</details>
+
+<details>
+<summary><strong>Dart / Flutter</strong> (native — no binary, any platform)</summary>
+
+```dart
+import 'ttid_native.dart';
+
+final id = Ttid.generate();               // new id
+final updated = Ttid.generate(id);        // advance it
+Ttid.generate(updated, true);             // mark deleted
+Ttid.decodeTime(updated);                 // { createdAt, updatedAt } (ms)
+Ttid.isTtid(id);                          // DateTime if valid, else null
+Ttid.isUuid('not-a-uuid');                // RegExpMatch if valid, else null
 ```
 
 </details>

--- a/clients/README.md
+++ b/clients/README.md
@@ -17,15 +17,18 @@ file for your language and call TTID like a library.
 | Swift         | `swift/Ttid.swift`     | none (Foundation) |
 | Kotlin        | `kotlin/Ttid.kt`       | none (JDK)      |
 | Dart          | `dart/ttid.dart`       | none (stdlib)   |
+| Dart (Flutter)| `dart/ttid_native.dart`| none — no binary |
 | Web (browser) | `web/ttid.mjs`         | none — no binary |
 
-> **The web client is different.** A browser can't spawn a subprocess, so
-> `web/ttid.mjs` does **not** drive the `ttid` binary — it reimplements TTID
-> natively in pure JavaScript. It needs no binary and no install; just import it.
-> Its API mirrors the TTID library's static methods (`TTID.generate(...)`,
-> `TTID.isTTID(...)` → `Date | null`, `TTID.isUUID(...)` → `RegExpMatchArray | null`),
-> not the machine protocol below. Everything else in this document describes the
-> binary-driven clients.
+> **Two native clients are different.** A browser and Flutter on mobile/web can't
+> spawn a subprocess, so `web/ttid.mjs` (JavaScript) and `dart/ttid_native.dart`
+> (Dart/Flutter) do **not** drive the `ttid` binary — they reimplement TTID
+> natively in pure JS / pure Dart. No binary, no install; just import. Their APIs
+> mirror the TTID library's static methods (`generate`, `decodeTime`, `isTtid`
+> → date/null, `isUuid` → match/null) rather than the machine protocol below, and
+> their IDs interoperate with every other client. Use `dart/ttid.dart` (binary-
+> driven) only on a server/desktop that has the `ttid` binary. Everything else in
+> this document describes the binary-driven clients.
 
 ## Install the binary
 

--- a/clients/dart/ttid_native.dart
+++ b/clients/dart/ttid_native.dart
@@ -1,0 +1,110 @@
+// TTID native client — a self-contained, dependency-free implementation for
+// Dart and Flutter (any platform: mobile, web, desktop, server).
+//
+// Unlike `ttid.dart`, this build does NOT drive the `ttid` binary — it needs no
+// `dart:io` and no subprocess, so it runs where the binary can't: Flutter on
+// iOS/Android (sandboxed) and Flutter web (compiled to JS). TTID is pure
+// computation (base-36 timestamp encoding + validation), reimplemented here in
+// Dart core only. IDs are interoperable with every other TTID client.
+//
+//   import 'ttid_native.dart';
+//
+//   final id = Ttid.generate();              // new id, e.g. "4VLSK98UX1K"
+//   final updated = Ttid.generate(id);       // advance it
+//   final deleted = Ttid.generate(updated, true); // mark deleted (final state)
+//   Ttid.decodeTime(deleted);                // { createdAt, updatedAt, deletedAt } (ms)
+//   Ttid.isTtid(id);                         // DateTime if valid, else null
+//   Ttid.isUuid('not-a-uuid');               // RegExpMatch if valid, else null
+//
+// For a server/desktop app that has the `ttid` binary on PATH and wants to share
+// the compiled core, use the binary-driven client in `ttid.dart` instead.
+
+/// Namespace of pure-Dart TTID operations. All methods are static; no state,
+/// no process, no I/O.
+class Ttid {
+  Ttid._();
+
+  static const int _precision = 10000;
+  static const String _placeholder = 'X';
+  static const int _minTimestampMs = 1577836800000; // 2020-01-01T00:00:00.000Z
+  static const int _maxTimestampMs = 7258118400000; // 2200-01-01T00:00:00.000Z
+
+  static final RegExp _ttidPattern =
+      RegExp(r'^[A-Z0-9]{11}(-[A-Z0-9]{1,11}){0,2}$', caseSensitive: false);
+  static final RegExp _uuidPattern = RegExp(
+      r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+      caseSensitive: false);
+
+  /// Current high-resolution timestamp, scaled to preserve sub-ms precision.
+  /// `microsecondsSinceEpoch * 10` == `msSinceEpoch * PRECISION`.
+  static int _timeNow() => DateTime.now().microsecondsSinceEpoch * 10;
+
+  /// Decode the timestamps embedded in a TTID.
+  /// Throws [FormatException] if the format is invalid or a segment is out of range.
+  static Map<String, int> decodeTime(String id) {
+    if (!_ttidPattern.hasMatch(id)) throw const FormatException('Invalid Format!');
+
+    final parts = id.split('-');
+    final updated = parts.length > 1 ? parts[1] : null;
+    final deleted = parts.length > 2 ? parts[2] : null;
+
+    int toMs(String code) {
+      final ms = (int.parse(code, radix: 36) / _precision).round();
+      if (ms < _minTimestampMs || ms > _maxTimestampMs) {
+        throw const FormatException('Invalid timestamp encoding');
+      }
+      return ms;
+    }
+
+    final result = <String, int>{'createdAt': toMs(parts[0])};
+    if (updated != null && updated != _placeholder) result['updatedAt'] = toMs(updated);
+    if (deleted != null) result['deletedAt'] = toMs(deleted);
+    return result;
+  }
+
+  /// Validate a TTID. Returns the creation [DateTime] if valid, else `null`.
+  static DateTime? isTtid(String id) {
+    if (id.isEmpty || id.length > 36) return null;
+    if (!_ttidPattern.hasMatch(id)) return null;
+    try {
+      return DateTime.fromMillisecondsSinceEpoch(decodeTime(id)['createdAt']!);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Validate a UUID (any version or variant). Returns the match, else `null`.
+  static RegExpMatch? isUuid(String id) => _uuidPattern.firstMatch(id);
+
+  /// Generate a new TTID, or advance an existing one through its lifecycle.
+  ///
+  /// - no args: mints a new single-segment TTID
+  /// - [id] only: advances it (a second segment)
+  /// - [id] + [delete]: tombstones it (a third segment)
+  ///
+  /// Throws if [id] is already deleted (three segments) or is not a valid TTID.
+  static String generate([String? id, bool delete = false]) {
+    if (id != null && isTtid(id) != null && id.split('-').length == 3) {
+      throw StateError('This identifier can no longer be modified');
+    }
+
+    final time = _timeNow();
+
+    if (id != null && isTtid(id) != null && delete) {
+      final parts = id.split('-');
+      final updated = parts.length > 1 ? parts[1] : _placeholder;
+      final deleted = time.toRadixString(36);
+      return '${parts[0]}-$updated-$deleted'.toUpperCase();
+    }
+
+    if (id != null && isTtid(id) != null) {
+      final created = id.split('-')[0];
+      final updated = time.toRadixString(36);
+      return '$created-$updated'.toUpperCase();
+    }
+
+    if (id != null && isTtid(id) == null) throw ArgumentError('Invalid TTID!');
+
+    return time.toRadixString(36).toUpperCase();
+  }
+}


### PR DESCRIPTION
The binary-driven Dart client (`clients/dart/ttid.dart`) only works where a subprocess can be spawned — i.e. Flutter/Dart **desktop and server**. It can't run on:

- **Flutter mobile** (iOS/Android) — the sandbox forbids spawning a bundled executable
- **Flutter web** — `dart:io` doesn't exist when Dart compiles to JS

This adds **`clients/dart/ttid_native.dart`** — a dependency-free, pure-Dart reimplementation (the Dart analog of the native web JS client). No `dart:io`, no binary, so it runs **anywhere Dart runs, including Flutter on every platform**.

- Static API: `Ttid.generate` / `decodeTime` / `isTtid` (→ `DateTime?`) / `isUuid` (→ `RegExpMatch?`)
- IDs **interoperate** with every other client — verified by cross-decoding a binary-generated id in Dart

Docs updated to distinguish the two native clients (web + Dart) from the binary-driven ones; clients badge → 13.

**Verified**: `dart analyze` clean; full lifecycle (create → advance → delete, decode, validate, immutability) and cross-decode of a binary id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)