### PR TITLE
feat(clients): add native Swift (iOS) and Kotlin (Android) clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/d31ma/TTID/releases/latest"><img src="https://img.shields.io/github/v/release/d31ma/TTID?label=release&color=2ea043" alt="Latest release"></a>
   <a href="https://github.com/d31ma/TTID/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/d31ma/TTID/ci.yml?branch=main&label=build" alt="Build status"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license"></a>
-  <img src="https://img.shields.io/badge/clients-13-8957e5" alt="13 clients">
+  <img src="https://img.shields.io/badge/clients-15-8957e5" alt="15 clients">
   <a href="https://github.com/d31ma/TTID/stargazers"><img src="https://img.shields.io/github/stars/d31ma/TTID?style=flat&color=e3b341" alt="GitHub stars"></a>
 </p>
 
@@ -237,12 +237,14 @@ names follow each language's own convention — `snake_case`, `camelCase`, or
 | C# | [`clients/csharp/Ttid.cs`](clients/csharp/Ttid.cs) | `PascalCase` |
 | Java | [`clients/java/Ttid.java`](clients/java/Ttid.java) | `camelCase` |
 | Swift | [`clients/swift/Ttid.swift`](clients/swift/Ttid.swift) | `camelCase` |
+| Swift (iOS) | [`clients/swift/TtidNative.swift`](clients/swift/TtidNative.swift) | native — no binary |
 | Kotlin | [`clients/kotlin/Ttid.kt`](clients/kotlin/Ttid.kt) | `camelCase` |
+| Kotlin (Android) | [`clients/kotlin/TtidNative.kt`](clients/kotlin/TtidNative.kt) | native — no binary |
 | Dart | [`clients/dart/ttid.dart`](clients/dart/ttid.dart) | `camelCase` |
 | Dart (Flutter) | [`clients/dart/ttid_native.dart`](clients/dart/ttid_native.dart) | native — no binary |
 | Web (browser) | [`clients/web/ttid.mjs`](clients/web/ttid.mjs) | native — no binary |
 
-> The **web** and **Flutter** clients are native (pure JS / pure Dart) — a browser and Flutter on mobile/web can't spawn the binary, so they reimplement TTID directly and mirror the library's static API. Their IDs still interoperate with every other client. Use `clients/dart/ttid.dart` on a server/desktop that has the binary.
+> The **native** clients — Web (JS), iOS (Swift), Android (Kotlin), Flutter (Dart) — reimplement TTID directly instead of driving the binary, because browsers and mobile OSes can't spawn a subprocess. They mirror the library's static API and their IDs still interoperate with every other client. Use the binary-driven `Ttid.swift` / `Ttid.kt` / `ttid.dart` on a server/desktop that has the binary.
 
 <details open>
 <summary><strong>Python</strong></summary>
@@ -422,6 +424,34 @@ print(await t.decodeTime(id));              // {createdAt: ..., updatedAt: ...}
 print(await t.isTtid(id));                  // {valid: true, createdAt: ...}
 print(await t.isUuid('not-a-uuid'));        // {valid: false}
 await t.close();
+```
+
+</details>
+
+<details>
+<summary><strong>Swift / iOS</strong> (native — no binary)</summary>
+
+```swift
+let id = try TtidNative.generate()            // new id
+let updated = try TtidNative.generate(id)     // advance it
+_ = try TtidNative.generate(updated, delete: true) // mark deleted
+try TtidNative.decodeTime(updated)            // ["createdAt": ..., "updatedAt": ...]
+TtidNative.isTTID(id)                         // Date if valid, else nil
+TtidNative.isUUID("not-a-uuid")              // Bool
+```
+
+</details>
+
+<details>
+<summary><strong>Kotlin / Android</strong> (native — no binary)</summary>
+
+```kotlin
+val id = TtidNative.generate()               // new id
+val updated = TtidNative.generate(id)        // advance it
+TtidNative.generate(updated, true)           // mark deleted
+TtidNative.decodeTime(updated)               // {createdAt=..., updatedAt=...}
+TtidNative.isTTID(id)                         // Date if valid, else null
+TtidNative.isUUID("not-a-uuid")              // Boolean
 ```
 
 </details>

--- a/clients/README.md
+++ b/clients/README.md
@@ -14,21 +14,25 @@ file for your language and call TTID like a library.
 | Rust          | `rust/ttid.rs`         | none (std)      |
 | C#            | `csharp/Ttid.cs`       | none (BCL)      |
 | Java          | `java/Ttid.java`       | none (JDK)      |
-| Swift         | `swift/Ttid.swift`     | none (Foundation) |
-| Kotlin        | `kotlin/Ttid.kt`       | none (JDK)      |
-| Dart          | `dart/ttid.dart`       | none (stdlib)   |
-| Dart (Flutter)| `dart/ttid_native.dart`| none — no binary |
-| Web (browser) | `web/ttid.mjs`         | none — no binary |
+| Swift         | `swift/Ttid.swift`       | none (Foundation) |
+| Swift (iOS)   | `swift/TtidNative.swift` | none — no binary |
+| Kotlin        | `kotlin/Ttid.kt`         | none (JDK)      |
+| Kotlin (Android) | `kotlin/TtidNative.kt` | none — no binary |
+| Dart          | `dart/ttid.dart`         | none (stdlib)   |
+| Dart (Flutter)| `dart/ttid_native.dart`  | none — no binary |
+| Web (browser) | `web/ttid.mjs`           | none — no binary |
 
-> **Two native clients are different.** A browser and Flutter on mobile/web can't
-> spawn a subprocess, so `web/ttid.mjs` (JavaScript) and `dart/ttid_native.dart`
-> (Dart/Flutter) do **not** drive the `ttid` binary — they reimplement TTID
-> natively in pure JS / pure Dart. No binary, no install; just import. Their APIs
-> mirror the TTID library's static methods (`generate`, `decodeTime`, `isTtid`
-> → date/null, `isUuid` → match/null) rather than the machine protocol below, and
-> their IDs interoperate with every other client. Use `dart/ttid.dart` (binary-
-> driven) only on a server/desktop that has the `ttid` binary. Everything else in
-> this document describes the binary-driven clients.
+> **The native clients are different.** A browser, iOS, Android, and Flutter on
+> mobile/web can't spawn a subprocess, so the four `*Native`/`web` clients —
+> `web/ttid.mjs` (JS), `swift/TtidNative.swift` (iOS), `kotlin/TtidNative.kt`
+> (Android), and `dart/ttid_native.dart` (Flutter) — do **not** drive the `ttid`
+> binary. They reimplement TTID natively in the host language (no binary, no
+> install; just import). Their APIs mirror the TTID library's static methods
+> (`generate`, `decodeTime`, `isTTID`/`isTtid` → date/null, `isUUID`/`isUuid`)
+> rather than the machine protocol below, and their IDs interoperate with every
+> other client. Use the binary-driven `Ttid.swift` / `Ttid.kt` / `ttid.dart` only
+> on a server/desktop that has the `ttid` binary. Everything else in this document
+> describes the binary-driven clients.
 
 ## Install the binary
 

--- a/clients/kotlin/TtidNative.kt
+++ b/clients/kotlin/TtidNative.kt
@@ -1,0 +1,107 @@
+// TTID native client — a self-contained, dependency-free implementation for
+// Kotlin on any platform, including Android.
+//
+// Unlike `Ttid.kt`, this build does NOT drive the `ttid` binary — it spawns no
+// subprocess, so it runs on Android (where bundling and exec-ing a native
+// binary isn't practical) as well as the JVM. TTID is pure computation (base-36
+// timestamp encoding + validation), reimplemented here with the JDK only. IDs
+// are interoperable with every other TTID client.
+//
+//   val id = TtidNative.generate()               // new id, e.g. "4VLSK98UX1K"
+//   val updated = TtidNative.generate(id)        // advance it
+//   val deleted = TtidNative.generate(updated, true) // final state
+//   TtidNative.decodeTime(deleted)               // {createdAt=..., ...} (ms)
+//   TtidNative.isTTID(id)                         // Date if valid, else null
+//   TtidNative.isUUID("not-a-uuid")              // Boolean
+//
+// For a JVM server or CLI that has the `ttid` binary, use the binary-driven
+// client in `Ttid.kt` instead.
+
+import java.time.Instant
+import java.util.Date
+
+/** Namespace of pure-Kotlin TTID operations. No state, no process, no I/O. */
+object TtidNative {
+    private const val PRECISION = 10_000L
+    private const val PLACEHOLDER = "X"
+    private const val MIN_TIMESTAMP_MS = 1_577_836_800_000L
+    private const val MAX_TIMESTAMP_MS = 7_258_118_400_000L
+
+    private val ttidPattern =
+        Regex("^[A-Z0-9]{11}(-[A-Z0-9]{1,11}){0,2}$", RegexOption.IGNORE_CASE)
+    private val uuidPattern = Regex(
+        "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        RegexOption.IGNORE_CASE
+    )
+
+    /** Current high-resolution timestamp: microseconds * 10 == ms * PRECISION. */
+    private fun timeNow(): Long {
+        val now = Instant.now()
+        val micros = now.epochSecond * 1_000_000L + now.nano / 1000L
+        return micros * 10L
+    }
+
+    /**
+     * Decode the timestamps embedded in a TTID.
+     * @throws IllegalArgumentException if the format is invalid or out of range.
+     */
+    fun decodeTime(id: String): Map<String, Long> {
+        if (!ttidPattern.matches(id)) throw IllegalArgumentException("Invalid Format!")
+        val parts = id.split("-")
+
+        fun toMs(code: String): Long {
+            val ms = Math.round(code.toLong(36).toDouble() / PRECISION)
+            if (ms < MIN_TIMESTAMP_MS || ms > MAX_TIMESTAMP_MS) {
+                throw IllegalArgumentException("Invalid timestamp encoding")
+            }
+            return ms
+        }
+
+        val result = linkedMapOf("createdAt" to toMs(parts[0]))
+        if (parts.size > 1 && parts[1] != PLACEHOLDER) result["updatedAt"] = toMs(parts[1])
+        if (parts.size > 2) result["deletedAt"] = toMs(parts[2])
+        return result
+    }
+
+    /** Validate a TTID. Returns the creation [Date] if valid, else `null`. */
+    fun isTTID(id: String): Date? {
+        if (id.isEmpty() || id.length > 36) return null
+        if (!ttidPattern.matches(id)) return null
+        return try {
+            Date(decodeTime(id)["createdAt"]!!)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** Validate a UUID (any version or variant). */
+    fun isUUID(id: String): Boolean = uuidPattern.matches(id)
+
+    /**
+     * Generate a new TTID, or advance an existing one through its lifecycle.
+     * @throws IllegalStateException if `id` is already deleted (three segments).
+     * @throws IllegalArgumentException if `id` is not a valid TTID.
+     */
+    fun generate(id: String? = null, delete: Boolean = false): String {
+        if (id != null && isTTID(id) != null && id.split("-").size == 3) {
+            throw IllegalStateException("This identifier can no longer be modified")
+        }
+
+        val encoded = timeNow().toString(36).uppercase()
+
+        if (id != null && isTTID(id) != null && delete) {
+            val parts = id.split("-")
+            val updated = if (parts.size > 1) parts[1] else PLACEHOLDER
+            return "${parts[0]}-$updated-$encoded".uppercase()
+        }
+
+        if (id != null && isTTID(id) != null) {
+            val created = id.split("-")[0]
+            return "$created-$encoded".uppercase()
+        }
+
+        if (id != null && isTTID(id) == null) throw IllegalArgumentException("Invalid TTID!")
+
+        return encoded
+    }
+}

--- a/clients/swift/TtidNative.swift
+++ b/clients/swift/TtidNative.swift
@@ -1,0 +1,114 @@
+// TTID native client — a self-contained, dependency-free implementation for
+// Swift on any platform, including iOS.
+//
+// Unlike `Ttid.swift`, this build does NOT drive the `ttid` binary — it spawns
+// no subprocess, so it runs on iOS (where launching a separate executable is
+// forbidden) as well as macOS and Linux. TTID is pure computation (base-36
+// timestamp encoding + validation), reimplemented here with Foundation only.
+// IDs are interoperable with every other TTID client.
+//
+//   let id = try TtidNative.generate()             // new id, e.g. "4VLSK98UX1K"
+//   let updated = try TtidNative.generate(id)      // advance it
+//   let deleted = try TtidNative.generate(updated, delete: true) // final state
+//   try TtidNative.decodeTime(deleted)             // ["createdAt": ..., ...] (ms)
+//   TtidNative.isTTID(id)                          // Date if valid, else nil
+//   TtidNative.isUUID("not-a-uuid")                // Bool
+//
+// For a macOS/Linux server or CLI that has the `ttid` binary, use the
+// binary-driven client in `Ttid.swift` instead.
+
+import Foundation
+
+enum TtidNativeError: Error, CustomStringConvertible {
+    case failure(String)
+    var description: String {
+        switch self { case .failure(let message): return message }
+    }
+}
+
+/// Namespace of pure-Swift TTID operations. All methods are static; no state,
+/// no process, no I/O.
+enum TtidNative {
+    private static let precision = 10_000
+    private static let placeholder = "X"
+    private static let minTimestampMs = 1_577_836_800_000
+    private static let maxTimestampMs = 7_258_118_400_000
+
+    private static let ttidRegex = try! NSRegularExpression(
+        pattern: "^[A-Z0-9]{11}(-[A-Z0-9]{1,11}){0,2}$", options: [.caseInsensitive])
+    private static let uuidRegex = try! NSRegularExpression(
+        pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        options: [.caseInsensitive])
+
+    private static func matches(_ regex: NSRegularExpression, _ s: String) -> Bool {
+        regex.firstMatch(in: s, options: [], range: NSRange(s.startIndex..., in: s)) != nil
+    }
+
+    /// Current high-resolution timestamp: microseconds * 10 == ms * PRECISION.
+    private static func timeNow() -> Int {
+        Int(Date().timeIntervalSince1970 * 1_000_000) * 10
+    }
+
+    /// Decode the timestamps embedded in a TTID.
+    /// Throws if the format is invalid or a segment is out of range.
+    static func decodeTime(_ id: String) throws -> [String: Int] {
+        guard matches(ttidRegex, id) else { throw TtidNativeError.failure("Invalid Format!") }
+        let parts = id.components(separatedBy: "-")
+
+        func toMs(_ code: String) throws -> Int {
+            guard let value = Int(code, radix: 36) else {
+                throw TtidNativeError.failure("Invalid timestamp encoding")
+            }
+            let ms = Int((Double(value) / Double(precision)).rounded())
+            if ms < minTimestampMs || ms > maxTimestampMs {
+                throw TtidNativeError.failure("Invalid timestamp encoding")
+            }
+            return ms
+        }
+
+        var result = ["createdAt": try toMs(parts[0])]
+        if parts.count > 1 && parts[1] != placeholder { result["updatedAt"] = try toMs(parts[1]) }
+        if parts.count > 2 { result["deletedAt"] = try toMs(parts[2]) }
+        return result
+    }
+
+    /// Validate a TTID. Returns the creation `Date` if valid, else `nil`.
+    static func isTTID(_ id: String) -> Date? {
+        if id.isEmpty || id.count > 36 { return nil }
+        if !matches(ttidRegex, id) { return nil }
+        guard let created = try? decodeTime(id)["createdAt"] else { return nil }
+        return Date(timeIntervalSince1970: Double(created) / 1000.0)
+    }
+
+    /// Validate a UUID (any version or variant).
+    static func isUUID(_ id: String) -> Bool {
+        matches(uuidRegex, id)
+    }
+
+    /// Generate a new TTID, or advance an existing one through its lifecycle.
+    /// Throws if `id` is already deleted (three segments) or is not a valid TTID.
+    static func generate(_ id: String? = nil, delete: Bool = false) throws -> String {
+        if let id = id, isTTID(id) != nil, id.components(separatedBy: "-").count == 3 {
+            throw TtidNativeError.failure("This identifier can no longer be modified")
+        }
+
+        let encoded = String(timeNow(), radix: 36, uppercase: true)
+
+        if let id = id, isTTID(id) != nil, delete {
+            let parts = id.components(separatedBy: "-")
+            let updated = parts.count > 1 ? parts[1] : placeholder
+            return "\(parts[0])-\(updated)-\(encoded)".uppercased()
+        }
+
+        if let id = id, isTTID(id) != nil {
+            let created = id.components(separatedBy: "-")[0]
+            return "\(created)-\(encoded)".uppercased()
+        }
+
+        if let id = id, isTTID(id) == nil {
+            throw TtidNativeError.failure("Invalid TTID!")
+        }
+
+        return encoded
+    }
+}


### PR DESCRIPTION
The binary-driven Swift/Kotlin clients (`Ttid.swift`, `Ttid.kt`) only run where a subprocess can be spawned — macOS/Linux/JVM desktop & server. They can't run on the platforms those languages are most used for:

- **iOS (Swift)** — the sandbox forbids launching a separate executable
- **Android (Kotlin)** — bundling and exec-ing a native binary isn't practical

Same gap we filled for the browser and Flutter. This adds dependency-free **native** reimplementations:

- **`clients/swift/TtidNative.swift`** — Foundation only, no `Process`; `TtidNative.generate` / `decodeTime` / `isTTID` (→ `Date?`) / `isUUID` (→ `Bool`)
- **`clients/kotlin/TtidNative.kt`** — JDK only, no `ProcessBuilder`; `object TtidNative` with the same API

Both are **interoperable** — verified by cross-decoding a binary-generated id in each. Docs updated to group the four native clients (Web, iOS, Android, Flutter); clients badge → 15.

**Verified**: Swift compiled & run, Kotlin compiled & run — full lifecycle (create → advance → delete, decode, validate, immutability) + cross-decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)